### PR TITLE
Add inital CDI code

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install golint
       run: go get -u golang.org/x/lint/golint
     - name: Lint
-      run: golint -set_exit_status ./specs-go/*.go
+      run: golint -set_exit_status ./specs-go/*.go ./pkg/*
     - name: Fmt
       run: test -z "$(gofmt -l ./specs-go/config.go)"
     - name: Vet

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/container-orchestrated-devices/container-device-interface
 
 go 1.14
 
-require github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+require (
+	github.com/opencontainers/runtime-spec v1.0.2
+	github.com/sirupsen/logrus v1.7.0
+	github.com/stretchr/testify v1.3.0
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,16 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/opencontainers/runtime-spec v1.0.2 h1:UfAcuLBJB9Coz72x1hgl8O5RVzTdNiaglX6v2DM6FI0=
+github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
@@ -8,3 +18,5 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHo
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/devices.go
+++ b/pkg/devices.go
@@ -1,0 +1,180 @@
+package pkg
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	cdispec "github.com/container-orchestrated-devices/container-device-interface/specs-go"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+const (
+	root = "/etc/cdi"
+)
+
+func collectCDISpecs() (map[string]*cdispec.Spec, error) {
+	var files []string
+	vendor := make(map[string]*cdispec.Spec)
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if info == nil || info.IsDir() {
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		files = append(files, path)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, path := range files {
+		spec, err := loadCDIFile(path)
+		if err != nil {
+			continue
+		}
+
+		if _, ok := vendor[spec.Kind]; ok {
+			continue
+		}
+
+		vendor[spec.Kind] = spec
+	}
+
+	return vendor, nil
+}
+
+// TODO: Validate (e.g: duplicate device names)
+func loadCDIFile(path string) (*cdispec.Spec, error) {
+	file, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var spec *cdispec.Spec
+	err = json.Unmarshal([]byte(file), &spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return spec, nil
+}
+
+/*
+* Pattern "vendor.com/device=myDevice" with the vendor being optional
+ */
+func extractVendor(dev string) (string, string) {
+	if strings.IndexByte(dev, '=') == -1 {
+		return "", dev
+	}
+
+	split := strings.SplitN(dev, "=", 2)
+	return split[0], split[1]
+}
+
+// GetCDIForDevice returns the CDI specification that matches the device name the user provided.
+func GetCDIForDevice(dev string, specs map[string]*cdispec.Spec) (*cdispec.Spec, error) {
+	vendor, device := extractVendor(dev)
+
+	if vendor != "" {
+		s, ok := specs[vendor]
+		if !ok {
+			return nil, fmt.Errorf("Could not find vendor %q for device %q", vendor, device)
+		}
+
+		for _, d := range s.Devices {
+			if d.Name != device {
+				continue
+			}
+
+			return s, nil
+		}
+
+		return nil, fmt.Errorf("Could not find device %q for vendor %q", device, vendor)
+	}
+
+	var found []*cdispec.Spec
+	var vendors []string
+	for vendor, spec := range specs {
+
+		for _, d := range spec.Devices {
+			if d.Name != device {
+				continue
+			}
+
+			found = append(found, spec)
+			vendors = append(vendors, vendor)
+		}
+	}
+
+	if len(found) > 1 {
+		return nil, fmt.Errorf("%q is ambiguous and currently refers to multiple devices from different vendors: %q", dev, vendors)
+	}
+
+	if len(found) == 1 {
+		return found[0], nil
+	}
+
+	return nil, fmt.Errorf("Could not find device %q", dev)
+}
+
+// HasDevice returns true if a device is a CDI device
+// an error may be returned in cases where permissions may be required
+func HasDevice(dev string) (bool, error) {
+	specs, err := collectCDISpecs()
+	if err != nil {
+		return false, err
+	}
+
+	d, err := GetCDIForDevice(dev, specs)
+	if err != nil {
+		return false, err
+	}
+
+	return d != nil, nil
+}
+
+// UpdateOCISpecForDevices updates the given OCI spec based on the requested CDI devices
+func UpdateOCISpecForDevices(ociconfig *spec.Spec, devs []string) error {
+	specs, err := collectCDISpecs()
+	if err != nil {
+		return err
+	}
+
+	return UpdateOCISpecForDevicesWithSpec(ociconfig, devs, specs)
+}
+
+// UpdateOCISpecForDevicesWithLoggerAndSpecs is mainly used for testing
+func UpdateOCISpecForDevicesWithSpec(ociconfig *spec.Spec, devs []string, specs map[string]*cdispec.Spec) error {
+	edits := make(map[string]*cdispec.Spec)
+
+	for _, d := range devs {
+		spec, err := GetCDIForDevice(d, specs)
+		if err != nil {
+			return err
+		}
+
+		edits[spec.Kind] = spec
+		err = cdispec.ApplyOCIEditsForDevice(ociconfig, spec, d)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, spec := range edits {
+		if err := cdispec.ApplyOCIEdits(ociconfig, spec); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/devices_test.go
+++ b/pkg/devices_test.go
@@ -1,0 +1,195 @@
+package pkg
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	cdispec "github.com/container-orchestrated-devices/container-device-interface/specs-go"
+)
+
+
+func TestExtractVendor(t *testing.T) {
+	testcases := []struct {
+		dev            string
+		expectedVendor string
+		expectedDevice string
+	}{
+		{
+			dev:            "vendor.com/device=myDevice",
+			expectedVendor: "vendor.com/device",
+			expectedDevice: "myDevice",
+		},
+		{
+			dev:            "vendor.com/device=all", // make sure this isn't a special case
+			expectedVendor: "vendor.com/device",
+			expectedDevice: "all",
+		},
+		{
+			dev:            "myDevice",
+			expectedVendor: "",
+			expectedDevice: "myDevice",
+		},
+	}
+
+	for _, test := range testcases {
+		v, d := extractVendor(test.dev)
+		require.Equal(t, v, test.expectedVendor)
+		require.Equal(t, d, test.expectedDevice)
+	}
+}
+
+func TestGetCDIForDevice(t *testing.T) {
+	testcases := []struct {
+		testname string
+		getdev   string
+		specs    map[string]*cdispec.Spec
+
+		expectedKind  string
+		expectedError bool
+	}{
+		{
+			testname: "simple - Get Existing device",
+			getdev:   "vendor.com/device=myDevice",
+
+			specs: map[string]*cdispec.Spec{
+				"vendor.com/device": {
+					Kind: "vendor.com/device",
+					Devices: []cdispec.Devices{
+						{Name: "myDevice"},
+						{Name: "myDevice-2"},
+					},
+				},
+			},
+			expectedKind:  "vendor.com/device",
+			expectedError: false,
+		},
+		{
+			testname: "simple - Get non existing vendor",
+			getdev:   "foovendor.com/device=myDevice3",
+
+			specs: map[string]*cdispec.Spec{
+				"vendor.com/device": {
+					Kind: "vendor.com/device",
+					Devices: []cdispec.Devices{
+						{Name: "myDevice"},
+						{Name: "myDevice-2"},
+					},
+				},
+			},
+			expectedKind:  "",
+			expectedError: true,
+		},
+		{
+			testname: "simple - Get non existing device",
+			getdev:   "vendor.com/device=myDevice3",
+
+			specs: map[string]*cdispec.Spec{
+				"vendor.com/device": {
+					Kind: "vendor.com/device",
+					Devices: []cdispec.Devices{
+						{Name: "myDevice"},
+						{Name: "myDevice-2"},
+					},
+				},
+			},
+			expectedKind:  "",
+			expectedError: true,
+		},
+		{
+			testname: "simple - Get CDI with only device name",
+			getdev:   "myDevice",
+
+			specs: map[string]*cdispec.Spec{
+				"vendor.com/device": {
+					Kind: "vendor.com/device",
+					Devices: []cdispec.Devices{
+						{Name: "myDevice"},
+						{Name: "myDevice-2"},
+					},
+				},
+			},
+			expectedKind:  "vendor.com/device",
+			expectedError: false,
+		},
+		{
+			testname: "simple - Get non existing device and no vendor name",
+			getdev:   "myDevice3",
+
+			specs: map[string]*cdispec.Spec{
+				"vendor.com/device": {
+					Kind: "vendor.com/device",
+					Devices: []cdispec.Devices{
+						{Name: "myDevice"},
+						{Name: "myDevice-2"},
+					},
+				},
+			},
+			expectedKind:  "",
+			expectedError: true,
+		},
+		{
+			testname: "medium - device name is ambiguous",
+			getdev:   "myDevice",
+
+			specs: map[string]*cdispec.Spec{
+				"vendor.com/device": {
+					Kind: "vendor.com/device",
+					Devices: []cdispec.Devices{
+						{Name: "myDevice"},
+						{Name: "myDevice-2"},
+					},
+				},
+				"bar-vendor.com/device": {
+					Kind: "vendor.com/device",
+					Devices: []cdispec.Devices{
+						{Name: "myDevice"},
+						{Name: "myDevice-2"},
+					},
+				},
+			},
+			expectedKind:  "",
+			expectedError: true,
+		},
+		{
+			testname: "medium - get device multiple vendors",
+			getdev:   "myDevice-bar-2",
+
+			specs: map[string]*cdispec.Spec{
+				"foo-vendor.com/device": {
+					Kind: "foo-vendor.com/device",
+					Devices: []cdispec.Devices{
+						{Name: "myDevice-foo-1"},
+						{Name: "myDevice-foo-2"},
+					},
+				},
+				"bar-vendor.com/device": {
+					Kind: "bar-vendor.com/device",
+					Devices: []cdispec.Devices{
+						{Name: "mydevice-bar-1"},
+						{Name: "myDevice-bar-2"},
+					},
+				},
+				"baz-vendor.com/device": {
+					Kind: "baz-vendor.com/device",
+					Devices: []cdispec.Devices{
+						{Name: "mydevice-baz-1"},
+						{Name: "myDevice-baz-2"},
+					},
+				},
+			},
+			expectedKind:  "bar-vendor.com/device",
+			expectedError: false,
+		},
+	}
+
+	for _, test := range testcases {
+		s, err := GetCDIForDevice(test.getdev, test.specs)
+		if test.expectedError == true {
+			require.Error(t, err)
+			continue
+		}
+
+		require.NotNil(t, s)
+		require.Equal(t, test.expectedKind, s.Kind)
+	}
+}

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -20,23 +20,23 @@ type Devices struct {
 
 // ContainerEdits are edits a container runtime must make to the OCI spec to expose the device.
 type ContainerEdits struct {
-	DeviceNodes []DeviceNode `json:"deviceNodes,omitempty"`
-	Hooks       []Hook       `json:"hooks,omitempty"`
-	Mounts      []Mount      `json:"mounts,omitempty"`
+	DeviceNodes []*DeviceNode `json:"deviceNodes,omitempty"`
+	Hooks       []*Hook       `json:"hooks,omitempty"`
+	Mounts      []*Mount      `json:"mounts,omitempty"`
 }
 
 // DeviceNode represents a device node that needs to be added to the OCI spec.
 type DeviceNode struct {
-	HostPath      string `json:"hostPath"`
-	ContainerPath string `json:"containerPath"`
-	Permissions   string `json:"permissions,omitempty"`
+	HostPath      string   `json:"hostPath"`
+	ContainerPath string   `json:"containerPath"`
+	Permissions   []string `json:"permissions,omitempty"`
 }
 
 // Mount represents a mount that needs to be added to the OCI spec.
 type Mount struct {
-	HostPath      string `json:"hostPath"`
-	ContainerPath string `json:"containerPath"`
-	Options       string `json:"options,omitempty"`
+	HostPath      string   `json:"hostPath"`
+	ContainerPath string   `json:"containerPath"`
+	Options       []string `json:"options,omitempty"`
 }
 
 // Hook represents a hook that needs to be added to the OCI spec.
@@ -45,5 +45,5 @@ type Hook struct {
 	Path     string   `json:"path"`
 	Args     []string `json:"args,omitempty"`
 	Env      []string `json:"env,omitempty"`
-	Timeout  string   `json:"timeout,omitempty"`
+	Timeout  *int     `json:"timeout,omitempty"`
 }

--- a/specs-go/oci.go
+++ b/specs-go/oci.go
@@ -1,0 +1,87 @@
+package specs
+
+import (
+	"fmt"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// ApplyOCIEditsForDevice applies devices OCI edits, in other words
+// it finds the device in the CDI spec and applies the OCI patches that device
+// requires to the OCI specification.
+func ApplyOCIEditsForDevice(config *spec.Spec, cdi *Spec, dev string) error {
+	for _, d := range cdi.Devices {
+		if d.Name != dev {
+			continue
+		}
+
+		return ApplyEditsToOCISpec(config, &d.ContainerEdits)
+	}
+
+	return fmt.Errorf("CDI: device %q not found for spec %q", dev, cdi.Kind)
+}
+
+// ApplyOCIEdits applies the OCI edits the CDI spec declares globablly
+func ApplyOCIEdits(config *spec.Spec, cdi *Spec) error {
+	return ApplyEditsToOCISpec(config, &cdi.ContainerEdits)
+}
+
+// ApplyEditsToOCISpec applies the specified edits to the OCI spec.
+func ApplyEditsToOCISpec(config *spec.Spec, edits *ContainerEdits) error {
+	if edits == nil {
+		return nil
+	}
+
+	for _, d := range edits.DeviceNodes {
+		config.Mounts = append(config.Mounts, toOCIDevice(d))
+	}
+
+	for _, m := range edits.Mounts {
+		config.Mounts = append(config.Mounts, toOCIMount(m))
+	}
+
+	for _, h := range edits.Hooks {
+		switch h.HookName {
+		case "prestart":
+			config.Hooks.Prestart = append(config.Hooks.Prestart, toOCIHook(h))
+		case "createRuntime":
+			config.Hooks.CreateRuntime = append(config.Hooks.CreateRuntime, toOCIHook(h))
+		case "createContainer":
+			config.Hooks.CreateContainer = append(config.Hooks.CreateContainer, toOCIHook(h))
+		case "startContainer":
+			config.Hooks.StartContainer = append(config.Hooks.StartContainer, toOCIHook(h))
+		case "poststart":
+			config.Hooks.Poststart = append(config.Hooks.Poststart, toOCIHook(h))
+		case "poststop":
+			config.Hooks.Poststop = append(config.Hooks.Poststop, toOCIHook(h))
+		default:
+			fmt.Printf("CDI: Unknown hook %q\n", h.HookName)
+		}
+	}
+
+	return nil
+}
+
+func toOCIHook(h *Hook) spec.Hook {
+	return spec.Hook{
+		Path:    h.Path,
+		Args:    h.Args,
+		Env:     h.Env,
+		Timeout: h.Timeout,
+	}
+}
+
+func toOCIMount(m *Mount) spec.Mount {
+	return spec.Mount{
+		Source:      m.HostPath,
+		Destination: m.ContainerPath,
+		Options:     m.Options,
+	}
+}
+
+func toOCIDevice(d *DeviceNode) spec.Mount {
+	return spec.Mount{
+		Source:      d.HostPath,
+		Destination: d.ContainerPath,
+		Options:     d.Permissions,
+	}
+}


### PR DESCRIPTION
This Pull Request adds the initial code for CDI, we should then be able to import cdi/pkg from other projects with the following two functions:
- HasDevice -> Check if a Device given by a user is a CDI device
- UpdateOCISpecForDevices -> Update the OCI spec for a set of CDI device

This is missing tests for UpdateOCISpecForDevices but it's a first start.
This should also probably be optimized to cache the different files but these may come as a followup PR