### PR TITLE
add user to the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ $ cat > /etc/cdi/vendor.json <<EOF
       "FOO=VALID_SPEC",
       "BAR=BARVALUE1"
     ],
+    "user": {
+      "uid": 1000,
+      "gid": 1000,
+      "umask": 7,
+      "additionalGuids": [2, 8]
+    },
     "deviceNodes": [
       {"hostPath": "/dev/vendorctl", "containerPath": "/dev/vendorctl"}
     ],

--- a/SPEC.md
+++ b/SPEC.md
@@ -92,6 +92,12 @@ The key words "must", "must not", "required", "shall", "shall not", "should", "s
             "env": [ (optional)
                 "<envName>=<envValue>"
             ]
+            "user": { (optional)
+                "uid": <int>,
+                "gid": <int>,
+                "umask": <int>, (optional)
+                "additionalGids: [<int>] (optional)
+            }
             "deviceNodes": [ (optional)
                 {
                     "hostPath": "<path>",
@@ -163,7 +169,7 @@ Note: For a CDI file to be valid, at least one entry must be specified in this a
 
 #### OCI Edits
 
-The `containerEdits` field describes edits to be made to the OCI specification. Currently only four kinds of edits can be made to the OCI specification: `env`, `devices`, `mounts` and `hooks`.
+The `containerEdits` field describes edits to be made to the OCI specification. Currently the following kinds of edits can be made to the OCI specification: `env`, `user`, `devices`, `mounts` and `hooks`.
 
 The `containerEdits` field is referenced in two places in the specification:
   * At the device level, where the edits MUST only be made if the matching device is requested by the container runtime user.
@@ -172,6 +178,11 @@ The `containerEdits` field is referenced in two places in the specification:
 
 The `containerEdits` field has the following definition:
   * `env` (array of strings in the format of "VARNAME=VARVALUE", OPTIONAL) describes the environment variables that should be set. These values are appended to the container environment array.
+  * `user` (object, OPTIONAL) describes of which user the container process runs as:
+    * `uid` (int, REQUIRED) specifies the user ID in the container namespace.
+    * `gid` (int, REQUIRED) specifies the group ID in the container namespace.
+    * `umask` (int, OPTIONAL) specifies the [umask][umask_2] of the user.
+    * `additionalGids` (array of ints, OPTIONAL) specifies additional group IDs in the container namespace to be added to the container process.
   * `deviceNodes` (array of objects, OPTIONAL) describes the device nodes that should be mounted:
     * `hostPath` (string, REQUIRED) path of the device on the host.
     * `containerPath` (string, REQUIRED) path of the device within the container.

--- a/schema/defs.json
+++ b/schema/defs.json
@@ -12,11 +12,34 @@
                     "type": "string"
             }
         },
+        "ArrayOfUint32": {
+            "type": "array",
+            "items": {
+                "$ref": "#/devinitions/uint32"
+            }
+        },
         "FilePath": {
             "type": "string"
         },
         "Env": {
             "$ref": "#/definitions/ArrayOfStrings"
+        },
+        "User": {
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "$ref": "#/devinitions/uint32"
+                },
+                "gid": {
+                    "$ref": "#/devinitions/uint32"
+                },
+                "umask": {
+                    "$ref": "#/devinitions/uint32"
+                },
+                "additionalGids": {
+                    "$ref": "#/definitions/ArrayOfUint32"
+                }
+            }
         },
         "DeviceNode": {
             "type": "object",

--- a/schema/testdata/good/spec-example.json
+++ b/schema/testdata/good/spec-example.json
@@ -17,6 +17,7 @@
       "FOO=CDI_SPEC",
       "BAR=BARVALUE1"
     ],
+    "user": {"uid": 1000, "gid": 1000, "umask": 7, "additionalGids": [2, 8]},
     "deviceNodes": [
       {"hostPath": "/dev/vendorctl", "containerPath": "/dev/vendorctl"}
     ],

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -21,6 +21,7 @@ type Devices struct {
 // ContainerEdits are edits a container runtime must make to the OCI spec to expose the device.
 type ContainerEdits struct {
 	Env         []string      `json:"env,omitempty"`
+	User        *User         `json:"user,omitempty"`
 	DeviceNodes []*DeviceNode `json:"deviceNodes,omitempty"`
 	Hooks       []*Hook       `json:"hooks,omitempty"`
 	Mounts      []*Mount      `json:"mounts,omitempty"`
@@ -31,6 +32,14 @@ type DeviceNode struct {
 	HostPath      string   `json:"hostPath"`
 	ContainerPath string   `json:"containerPath"`
 	Permissions   []string `json:"permissions,omitempty"`
+}
+
+// User represents a user the container process runs as
+type User struct {
+	UID            uint32   `json:"uid"`
+	GID            uint32   `json:"gid"`
+	Umask          uint32   `json:"umask,omitempty"`
+	AdditionalGids []uint32 `json:"additionalgids,omitempty"`
 }
 
 // Mount represents a mount that needs to be added to the OCI spec.

--- a/specs-go/oci.go
+++ b/specs-go/oci.go
@@ -2,6 +2,7 @@ package specs
 
 import (
 	"fmt"
+
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -31,13 +32,15 @@ func ApplyEditsToOCISpec(config *spec.Spec, edits *ContainerEdits) error {
 		return nil
 	}
 
-	if len(edits.Env) > 0 {
-
-		if config.Process == nil {
-			config.Process = &spec.Process{}
+	if config.Process == nil {
+		fmt.Println("CDI: config: process is not defined")
+	} else {
+		if len(edits.Env) > 0 {
+			config.Process.Env = append(config.Process.Env, edits.Env...)
 		}
-
-		config.Process.Env = append(config.Process.Env, edits.Env...)
+		if edits.User != nil {
+			config.Process.User = spec.User{UID: edits.User.UID, GID: edits.User.GID, Umask: edits.User.Umask, AdditionalGids: edits.User.AdditionalGids}
+		}
 	}
 
 	for _, d := range edits.DeviceNodes {


### PR DESCRIPTION
Added 'User' object to the ociEdits section.
User fields and types were taken from the [OCI Runtime spec](https://github.com/opencontainers/runtime-spec/blob/master/config.md)

Fixes: #17