### PR TITLE
extend DeviceNode definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ $ cat > /etc/cdi/vendor.json <<EOF
       "name": "myDevice",
       "ociEdits": {
         "deviceNodes": [
-          {"hostPath": "/dev/card1", "containerPath": "/dev/card1"}
-          {"hostPath": "/dev/card-render1", "containerPath": "/dev/card-render1"}
+          {"path": "/dev/card1", type": "c", "major": 25, "minor": 25, "permissions": "rw", "uid": 1000, "gid": 1000}
+          {"path": "/dev/card-render1", "type": "c", "major": 25, "minor": 25, "permissions": "rwm", "uid": 1000, "gid": 1000}
         ]
       }
     }
@@ -44,7 +44,7 @@ $ cat > /etc/cdi/vendor.json <<EOF
       "BAR=BARVALUE1"
     ],
     "deviceNodes": [
-      {"hostPath": "/dev/vendorctl", "containerPath": "/dev/vendorctl"}
+      {"path": "/dev/vendorctl", "type": "b", "major": 25, "minor": 25, "permissions": "rw", "uid": 1000, "gid": 1000}
     ],
     "mounts": [
       {"hostPath": "/bin/vendorBin", "containerPath": "/bin/vendorBin"},

--- a/SPEC.md
+++ b/SPEC.md
@@ -94,14 +94,17 @@ The key words "must", "must not", "required", "shall", "shall not", "should", "s
             ]
             "deviceNodes": [ (optional)
                 {
-                    "hostPath": "<path>",
-                    "containerPath": "<path>",
-
+                    "path": "<path>",
+                    "type": "<type>" (optional),
+                    "major": <int32> (optional),
+                    "minor": <int32> (optional),
                     // Cgroups permissions of the device, candidates are one or more of
                     // * r - allows container to read from the specified device.
                     // * w - allows container to write to the specified device.
                     // * m - allows container to create device files that do not yet exist.
-                    "permissions": "<permissions>" (optional)
+                    "permissions": "<permissions>" (optional),
+                    "uid": <int> (optional),
+                    "gid": <int> (optional)
                 }
             ]
             "mounts": [ (optional)
@@ -163,7 +166,7 @@ Note: For a CDI file to be valid, at least one entry must be specified in this a
 
 #### OCI Edits
 
-The `containerEdits` field describes edits to be made to the OCI specification. Currently only four kinds of edits can be made to the OCI specification: `env`, `devices`, `mounts` and `hooks`.
+The `containerEdits` field describes edits to be made to the OCI specification. Currently the following kinds of edits can be made to the OCI specification: `env`, `devices`, `mounts` and `hooks`.
 
 The `containerEdits` field is referenced in two places in the specification:
   * At the device level, where the edits MUST only be made if the matching device is requested by the container runtime user.
@@ -173,12 +176,16 @@ The `containerEdits` field is referenced in two places in the specification:
 The `containerEdits` field has the following definition:
   * `env` (array of strings in the format of "VARNAME=VARVALUE", OPTIONAL) describes the environment variables that should be set. These values are appended to the container environment array.
   * `deviceNodes` (array of objects, OPTIONAL) describes the device nodes that should be mounted:
-    * `hostPath` (string, REQUIRED) path of the device on the host.
-    * `containerPath` (string, REQUIRED) path of the device within the container.
+    * `path` (string, REQUIRED) path of the device within the container.
+    * `type` (string, OPTIONAL) Device type: block, char, etc.
+    * `major` (int64, OPTIONAL) Device major number.
+    * `minor` (int64, OPTIONAL) Device minor number.
     * `permissions` (string, OPTIONAL) Cgroups permissions of the device, candidates are one or more of:
       * r - allows container to read from the specified device.
       * w - allows container to write to the specified device.
       * m - allows container to create device files that do not yet exist.
+    * `uid` (uint32, OPTIONAL) id of device owner in the container namespace.
+    * `gid` (uint32, OPTIONAL) id of device group in the container namespace.
   * `mounts` (array of objects, OPTIONAL) describes the mounts that should be mounted:
     * `hostPath` (string, REQUIRED) path of the device on the host.
     * `containerPath` (string, REQUIRED) path of the device within the container.

--- a/schema/defs.json
+++ b/schema/defs.json
@@ -6,6 +6,11 @@
             "minimum": 0,
             "maximum": 4294967295
         },
+        "int64": {
+            "type": "integer",
+            "minimum": -9223372036854775808,
+            "maximum": 9223372036854775807
+        },
         "ArrayOfStrings": {
             "type": "array",
             "items": {
@@ -21,19 +26,30 @@
         "DeviceNode": {
             "type": "object",
             "properties": {
-                "hostPath": {
-                    "$ref": "#/definitions/FilePath"
-                },
-                "containerPath": {
+                "path": {
                     "$ref": "#/definitions/FilePath"
                 },
                 "permissions": {
                     "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "major": {
+                    "$ref": "#/definitions/int64"
+                },
+                "minor": {
+                    "$ref": "#/definitions/int64"
+                },
+                "uid": {
+                    "$ref": "#/definitions/uint32"
+                },
+                "gid": {
+                    "$ref": "#/definitions/uint32"
                 }
             },
             "required": [
-                "hostPath",
-                "containerPath"
+                "path"
             ]
         },
         "Mount": {

--- a/schema/testdata/good/minimal.json
+++ b/schema/testdata/good/minimal.json
@@ -5,7 +5,7 @@
     {
       "name": "myDevice",
       "ociEdits": {
-        "deviceNodes": [{"hostPath": "/dev/card1", "containerPath": "/dev/card1"}]
+        "deviceNodes": [{"path": "/dev/card1"}]
       }
     }
   ]

--- a/schema/testdata/good/spec-example.json
+++ b/schema/testdata/good/spec-example.json
@@ -6,8 +6,8 @@
       "name": "myDevice",
       "ociEdits": {
         "deviceNodes": [
-          {"hostPath": "/dev/card1", "containerPath": "/dev/card1"},
-          {"hostPath": "/dev/card2", "containerPath": "/dev/card2"}
+          {"path": "/dev/card1"},
+          {"path": "/dev/card2"}
         ]
       }
     }
@@ -18,7 +18,7 @@
       "BAR=BARVALUE1"
     ],
     "deviceNodes": [
-      {"hostPath": "/dev/vendorctl", "containerPath": "/dev/vendorctl"}
+      {"path": "/dev/vendorctl", "uid": 1000, "gid": 1000}
     ],
     "mounts": [
       {"hostPath": "/bin/vendorBin", "containerPath": "/bin/vendorBin"},

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -28,9 +28,13 @@ type ContainerEdits struct {
 
 // DeviceNode represents a device node that needs to be added to the OCI spec.
 type DeviceNode struct {
-	HostPath      string   `json:"hostPath"`
-	ContainerPath string   `json:"containerPath"`
-	Permissions   []string `json:"permissions,omitempty"`
+	Path        string   `json:"path"`
+	Type        string   `json:"type,omitempty"`
+	Major       int64    `json:"major,omitempty"`
+	Minor       int64    `json:"minor,omitempty"`
+	Permissions []string `json:"permissions,omitempty"`
+	UID         *uint32  `json:"uid,omitempty"`
+	GID         *uint32  `json:"gid,omitempty"`
 }
 
 // Mount represents a mount that needs to be added to the OCI spec.

--- a/specs-go/oci.go
+++ b/specs-go/oci.go
@@ -37,16 +37,17 @@ func ApplyEditsToOCISpec(config *spec.Spec, edits *ContainerEdits) error {
 	}
 
 	if len(edits.Env) > 0 {
-
 		if config.Process == nil {
 			config.Process = &spec.Process{}
 		}
-
 		config.Process.Env = append(config.Process.Env, edits.Env...)
 	}
 
 	for _, d := range edits.DeviceNodes {
-		config.Mounts = append(config.Mounts, toOCIDevice(d))
+		if config.Linux == nil {
+			config.Linux = &spec.Linux{}
+		}
+		config.Linux.Devices = append(config.Linux.Devices, toOCILinuxDevice(d))
 	}
 
 	for _, m := range edits.Mounts {
@@ -97,8 +98,19 @@ func toOCIMount(m *Mount) spec.Mount {
 
 func toOCIDevice(d *DeviceNode) spec.Mount {
 	return spec.Mount{
-		Source:      d.HostPath,
-		Destination: d.ContainerPath,
+		Source:      d.Path,
+		Destination: d.Path,
 		Options:     d.Permissions,
+	}
+}
+
+func toOCILinuxDevice(d *DeviceNode) spec.LinuxDevice {
+	return spec.LinuxDevice{
+		Path:  d.Path,
+		Type:  d.Type,
+		Major: d.Major,
+		Minor: d.Minor,
+		UID:   d.UID,
+		GID:   d.GID,
 	}
 }

--- a/specs-go/oci_test.go
+++ b/specs-go/oci_test.go
@@ -42,16 +42,14 @@ func TestApplyEditsToOCISpec(t *testing.T) {
 			edits: &ContainerEdits{
 				DeviceNodes: []*DeviceNode{
 					{
-						HostPath:      "/dev/vendorctl",
-						ContainerPath: "/dev/vendorctl",
+						Path: "/dev/vendorctl",
 					},
 				},
 			},
 			expectedResult: spec.Spec{
-				Mounts: []spec.Mount{
-					{
-						Source:      "/dev/vendorctl",
-						Destination: "/dev/vendorctl",
+				Linux: &spec.Linux{
+					Devices: []spec.LinuxDevice{
+						{Path: "/dev/vendorctl"},
 					},
 				},
 			},
@@ -211,8 +209,7 @@ func TestApplyEditsToOCISpec(t *testing.T) {
 				Env: []string{"BAR=BARVALUE1"},
 				DeviceNodes: []*DeviceNode{
 					{
-						HostPath:      "/host/path",
-						ContainerPath: "/container/path",
+						Path: "/dev/device1",
 					},
 				},
 				Hooks: []*Hook{
@@ -245,16 +242,17 @@ func TestApplyEditsToOCISpec(t *testing.T) {
 					Readonly: true,
 				},
 				Hostname: "some.host.com",
+				Linux: &spec.Linux{
+					Devices: []spec.LinuxDevice{
+						{Path: "/dev/device1"},
+					},
+				},
 				Mounts: []spec.Mount{
 					{
 						Source:      "/source",
 						Destination: "/destination",
 						Type:        "tmpfs",
 						Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
-					},
-					{
-						Source:      "/host/path",
-						Destination: "/container/path",
 					},
 					{
 						Source:      "/mnt/mount1",
@@ -316,8 +314,7 @@ func TestApplyOCIEdits(t *testing.T) {
 					Env: []string{"FOO=VALID_SPEC", "BAR=BARVALUE1"},
 					DeviceNodes: []*DeviceNode{
 						{
-							HostPath:      "/dev/host-device",
-							ContainerPath: "/dev/container-device",
+							Path: "/dev/device1",
 						},
 					},
 				},
@@ -326,10 +323,9 @@ func TestApplyOCIEdits(t *testing.T) {
 				Process: &spec.Process{
 					Env: []string{"FOO=VALID_SPEC", "BAR=BARVALUE1"},
 				},
-				Mounts: []spec.Mount{
-					{
-						Source:      "/dev/host-device",
-						Destination: "/dev/container-device",
+				Linux: &spec.Linux{
+					Devices: []spec.LinuxDevice{
+						{Path: "/dev/device1"},
 					},
 				},
 			},
@@ -367,8 +363,7 @@ func TestApplyOCIEditsForDevice(t *testing.T) {
 							Env: []string{"FOO=VALID_SPEC", "BAR=BARVALUE1"},
 							DeviceNodes: []*DeviceNode{
 								{
-									HostPath:      "/dev/host-device",
-									ContainerPath: "/dev/container-device",
+									Path: "/dev/device1",
 								},
 							},
 						},
@@ -378,8 +373,7 @@ func TestApplyOCIEditsForDevice(t *testing.T) {
 						ContainerEdits: ContainerEdits{
 							DeviceNodes: []*DeviceNode{
 								{
-									HostPath:      "/dev/devABC",
-									ContainerPath: "/dev/devABC",
+									Path: "/dev/devABC",
 								},
 							},
 						},
@@ -390,10 +384,9 @@ func TestApplyOCIEditsForDevice(t *testing.T) {
 				Process: &spec.Process{
 					Env: []string{"FOO=VALID_SPEC", "BAR=BARVALUE1"},
 				},
-				Mounts: []spec.Mount{
-					{
-						Source:      "/dev/host-device",
-						Destination: "/dev/container-device",
+				Linux: &spec.Linux{
+					Devices: []spec.LinuxDevice{
+						{Path: "/dev/device1"},
 					},
 				},
 			},
@@ -410,8 +403,7 @@ func TestApplyOCIEditsForDevice(t *testing.T) {
 						ContainerEdits: ContainerEdits{
 							DeviceNodes: []*DeviceNode{
 								{
-									HostPath:      "/dev/devABC",
-									ContainerPath: "/dev/devABC",
+									Path: "/dev/devABC",
 								},
 							},
 						},


### PR DESCRIPTION
Added type, major, minor, uid and gid properties to the DeviceNode definition.
Property types were taken from the [OCI LinuxDevice](https://github.com/opencontainers/runtime-spec/blob/v1.0.2/specs-go/config.go#L377:L393).

Fixes: #26, #17