### PR TITLE
Remove unused toOCIDevice function

### DIFF
--- a/specs-go/oci.go
+++ b/specs-go/oci.go
@@ -96,14 +96,6 @@ func toOCIMount(m *Mount) spec.Mount {
 	}
 }
 
-func toOCIDevice(d *DeviceNode) spec.Mount {
-	return spec.Mount{
-		Source:      d.Path,
-		Destination: d.Path,
-		Options:     d.Permissions,
-	}
-}
-
 func toOCILinuxDevice(d *DeviceNode) spec.LinuxDevice {
 	return spec.LinuxDevice{
 		Path:  d.Path,


### PR DESCRIPTION
This change removes an unused toOCIDevice function that was converting a
CDI Device node to an OCI Mount. This is no longer required as the CDI devices
are now represented as OCI Linux Devices.

Signed-off-by: Evan Lezar <elezar@nvidia.com>