### PR TITLE
Rename specs.Devices to specs.Device

### DIFF
--- a/pkg/devices_test.go
+++ b/pkg/devices_test.go
@@ -1,12 +1,12 @@
 package pkg
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	cdispec "github.com/container-orchestrated-devices/container-device-interface/specs-go"
 )
-
 
 func TestExtractVendor(t *testing.T) {
 	testcases := []struct {
@@ -54,7 +54,7 @@ func TestGetCDIForDevice(t *testing.T) {
 			specs: map[string]*cdispec.Spec{
 				"vendor.com/device": {
 					Kind: "vendor.com/device",
-					Devices: []cdispec.Devices{
+					Devices: []cdispec.Device{
 						{Name: "myDevice"},
 						{Name: "myDevice-2"},
 					},
@@ -70,7 +70,7 @@ func TestGetCDIForDevice(t *testing.T) {
 			specs: map[string]*cdispec.Spec{
 				"vendor.com/device": {
 					Kind: "vendor.com/device",
-					Devices: []cdispec.Devices{
+					Devices: []cdispec.Device{
 						{Name: "myDevice"},
 						{Name: "myDevice-2"},
 					},
@@ -86,7 +86,7 @@ func TestGetCDIForDevice(t *testing.T) {
 			specs: map[string]*cdispec.Spec{
 				"vendor.com/device": {
 					Kind: "vendor.com/device",
-					Devices: []cdispec.Devices{
+					Devices: []cdispec.Device{
 						{Name: "myDevice"},
 						{Name: "myDevice-2"},
 					},
@@ -102,7 +102,7 @@ func TestGetCDIForDevice(t *testing.T) {
 			specs: map[string]*cdispec.Spec{
 				"vendor.com/device": {
 					Kind: "vendor.com/device",
-					Devices: []cdispec.Devices{
+					Devices: []cdispec.Device{
 						{Name: "myDevice"},
 						{Name: "myDevice-2"},
 					},
@@ -118,7 +118,7 @@ func TestGetCDIForDevice(t *testing.T) {
 			specs: map[string]*cdispec.Spec{
 				"vendor.com/device": {
 					Kind: "vendor.com/device",
-					Devices: []cdispec.Devices{
+					Devices: []cdispec.Device{
 						{Name: "myDevice"},
 						{Name: "myDevice-2"},
 					},
@@ -134,14 +134,14 @@ func TestGetCDIForDevice(t *testing.T) {
 			specs: map[string]*cdispec.Spec{
 				"vendor.com/device": {
 					Kind: "vendor.com/device",
-					Devices: []cdispec.Devices{
+					Devices: []cdispec.Device{
 						{Name: "myDevice"},
 						{Name: "myDevice-2"},
 					},
 				},
 				"bar-vendor.com/device": {
 					Kind: "vendor.com/device",
-					Devices: []cdispec.Devices{
+					Devices: []cdispec.Device{
 						{Name: "myDevice"},
 						{Name: "myDevice-2"},
 					},
@@ -157,21 +157,21 @@ func TestGetCDIForDevice(t *testing.T) {
 			specs: map[string]*cdispec.Spec{
 				"foo-vendor.com/device": {
 					Kind: "foo-vendor.com/device",
-					Devices: []cdispec.Devices{
+					Devices: []cdispec.Device{
 						{Name: "myDevice-foo-1"},
 						{Name: "myDevice-foo-2"},
 					},
 				},
 				"bar-vendor.com/device": {
 					Kind: "bar-vendor.com/device",
-					Devices: []cdispec.Devices{
+					Devices: []cdispec.Device{
 						{Name: "mydevice-bar-1"},
 						{Name: "myDevice-bar-2"},
 					},
 				},
 				"baz-vendor.com/device": {
 					Kind: "baz-vendor.com/device",
-					Devices: []cdispec.Devices{
+					Devices: []cdispec.Device{
 						{Name: "mydevice-baz-1"},
 						{Name: "myDevice-baz-2"},
 					},

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -7,12 +7,12 @@ type Spec struct {
 	KindShort        []string `json:"kindShort,omitempty"`
 	ContainerRuntime []string `json:"containerRuntime,omitempty"`
 
-	Devices        []Devices      `json:"devices"`
+	Devices        []Device       `json:"devices"`
 	ContainerEdits ContainerEdits `json:"containerEdits,omitempty"`
 }
 
-// Devices is a "Device" a container runtime can add to a container
-type Devices struct {
+// Device is a "Device" a container runtime can add to a container
+type Device struct {
 	Name           string         `json:"name"`
 	NameShort      []string       `json:"nameShort"`
 	ContainerEdits ContainerEdits `json:"containerEdits"`

--- a/specs-go/oci_test.go
+++ b/specs-go/oci_test.go
@@ -309,7 +309,7 @@ func TestApplyOCIEdits(t *testing.T) {
 			cdiSpec: &Spec{
 				Version: "0.2.0",
 				Kind:    "vendor.com/device",
-				Devices: []Devices{},
+				Devices: []Device{},
 				ContainerEdits: ContainerEdits{
 					Env: []string{"FOO=VALID_SPEC", "BAR=BARVALUE1"},
 					DeviceNodes: []*DeviceNode{
@@ -356,7 +356,7 @@ func TestApplyOCIEditsForDevice(t *testing.T) {
 			cdiSpec: &Spec{
 				Version: "0.2.0",
 				Kind:    "vendor.com/device",
-				Devices: []Devices{
+				Devices: []Device{
 					{
 						Name: "Vendor device XYZ",
 						ContainerEdits: ContainerEdits{
@@ -397,7 +397,7 @@ func TestApplyOCIEditsForDevice(t *testing.T) {
 			cdiSpec: &Spec{
 				Version: "0.2.0",
 				Kind:    "vendor.com/device",
-				Devices: []Devices{
+				Devices: []Device{
 					{
 						Name: "Vendor device ABC",
 						ContainerEdits: ContainerEdits{


### PR DESCRIPTION
This change renames the type specs.Devices to specs.Device as the intent
is to represent a single device. This improves the redability of the
Devices slice which how has the type []Device and not []Devices.

Signed-off-by: Evan Lezar <elezar@nvidia.com>