### PR TITLE
specs: sync Spec implementation and schema.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ $ cat > /etc/cdi/vendor.json <<EOF
   "devices": [
     {
       "name": "myDevice",
-      "ociEdits": {
+      "containerEdits": {
         "deviceNodes": [
-          {"path": "/dev/card1", type": "c", "major": 25, "minor": 25, "fileMode": 384, "permissions": "rw", "uid": 1000, "gid": 1000}
+          {"path": "/dev/card1", "type": "c", "major": 25, "minor": 25, "fileMode": 384, "permissions": "rw", "uid": 1000, "gid": 1000},
           {"path": "/dev/card-render1", "type": "c", "major": 25, "minor": 25, "fileMode": 384, "permissions": "rwm", "uid": 1000, "gid": 1000}
         ]
       }
     }
   ],
-  "ociEdits": {
+  "containerEdits": {
     "env": [
       "FOO=VALID_SPEC",
       "BAR=BARVALUE1"

--- a/schema/defs.json
+++ b/schema/defs.json
@@ -94,7 +94,7 @@
                 "path"
             ]
         },
-        "ociEdits": {
+        "containerEdits": {
             "type": "object",
             "properties": {
                 "env": {

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -32,13 +32,13 @@
                       "description": "A list of aliases which refers to the device",
                       "$ref": "defs.json#/definitions/ArrayOfStrings"
                     },
-                    "ociEdits": {
-                        "$ref": "defs.json#/definitions/ociEdits"
+                    "containerEdits": {
+                        "$ref": "defs.json#/definitions/containerEdits"
                     }
                 },
                 "required": [
                     "name",
-                    "ociEdits"
+                    "containerEdits"
                 ]
             }
         }

--- a/schema/testdata/good/minimal.json
+++ b/schema/testdata/good/minimal.json
@@ -4,7 +4,7 @@
   "devices": [
     {
       "name": "myDevice",
-      "ociEdits": {
+      "containerEdits": {
         "deviceNodes": [{"path": "/dev/card1"}]
       }
     }

--- a/schema/testdata/good/spec-example.json
+++ b/schema/testdata/good/spec-example.json
@@ -4,7 +4,7 @@
   "devices": [
     {
       "name": "myDevice",
-      "ociEdits": {
+      "containerEdits": {
         "deviceNodes": [
           {"path": "/dev/card1"},
           {"path": "/dev/card2"}
@@ -12,7 +12,7 @@
       }
     }
   ],
-  "ociEdits": {
+  "containerEdits": {
     "env": [
       "FOO=CDI_SPEC",
       "BAR=BARVALUE1"

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -35,7 +35,7 @@ type DeviceNode struct {
 	Major       int64        `json:"major,omitempty"`
 	Minor       int64        `json:"minor,omitempty"`
 	FileMode    *os.FileMode `json:"fileMode,omitempty"`
-	Permissions []string     `json:"permissions,omitempty"`
+	Permissions string       `json:"permissions,omitempty"`
 	UID         *uint32      `json:"uid,omitempty"`
 	GID         *uint32      `json:"gid,omitempty"`
 }


### PR DESCRIPTION
Sync Spec implementation and schema:
  - update DeviceNode.Permissions to be a string
  - change ociEdits in the schema to containerEdits
  - update schema validation tests

Additionally, fix a bunch of thinkos and typos in the sample JSON CDI Spec:
  - field name without leading quote ('type":')
  - old field names ("ociEdits" vs. "containerEdits")
  - a few missing and extra commas
