### PR TITLE
pkg/devices: fix UpdateOCISpecForDevicesWithSpec.

### DIFF
--- a/pkg/devices.go
+++ b/pkg/devices.go
@@ -153,7 +153,7 @@ func UpdateOCISpecForDevices(ociconfig *spec.Spec, devs []string) error {
 	return UpdateOCISpecForDevicesWithSpec(ociconfig, devs, specs)
 }
 
-// UpdateOCISpecForDevicesWithLoggerAndSpecs is mainly used for testing
+// UpdateOCISpecForDevicesWithSpec updates the given OCI spec based on the requested CDI devices using the given CDI specs.
 func UpdateOCISpecForDevicesWithSpec(ociconfig *spec.Spec, devs []string, specs map[string]*cdispec.Spec) error {
 	edits := make(map[string]*cdispec.Spec)
 
@@ -164,7 +164,8 @@ func UpdateOCISpecForDevicesWithSpec(ociconfig *spec.Spec, devs []string, specs 
 		}
 
 		edits[spec.Kind] = spec
-		err = cdispec.ApplyOCIEditsForDevice(ociconfig, spec, d)
+		_, device := extractVendor(d)
+		err = cdispec.ApplyOCIEditsForDevice(ociconfig, spec, device)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Align `UpdateOCISpecForDevicesWithSpec()` with `collectCDISpecs()`. The latter uses `extractVendor()`ed devices names to look up `CDI Specs`. Consequently the former must do the same when updating `OCI Spec`s with the collected CDI ones. Otherwise the update will fail for fully qualified CDI device names (ones which are of the form `vendor/type=name`).

While at it, also fix the incorrect doc-string for the same function and add a minimal set of test cases for it.
