### PR TITLE
Prepare for v0.3.0 Spec release

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Additionally runtimes don't uniformly expose a plugin system (or even expose a p
 $ mkdir /etc/cdi
 $ cat > /etc/cdi/vendor.json <<EOF
 {
-  "cdiVersion": "0.2.0",
+  "cdiVersion": "0.3.0",
   "kind": "vendor.com/device",
   "devices": [
     {

--- a/SPEC.md
+++ b/SPEC.md
@@ -70,7 +70,6 @@ The key words "must", "must not", "required", "shall", "shall not", "should", "s
 {
     "cdiVersion": "0.1.0",
     "kind": "<name>",
-    "containerRuntime": ["<container-runtime-name>"], (optional)
 
     "devices": [
         {
@@ -97,7 +96,7 @@ The key words "must", "must not", "required", "shall", "shall not", "should", "s
                     "major": <int32> (optional),
                     "minor": <int32> (optional),
                     // file mode for the device
-                    "fileMode": <int> (optional), 
+                    "fileMode": <int> (optional),
                     // Cgroups permissions of the device, candidates are one or more of
                     // * r - allows container to read from the specified device.
                     // * w - allows container to write to the specified device.
@@ -142,12 +141,6 @@ The key words "must", "must not", "required", "shall", "shall not", "should", "s
     * Examples (not an exhaustive list):
       * Valid: `vendor.com/foo`, `foo.bar.baz/foo-bar123.B_az`.
       * Invalid: `foo`, `vendor.com/foo/`, `vendor.com/foo/bar`.
-
-#### Container Runtime
-
-* `containerRuntime` (array of string, OPTIONAL) indicates that this CDI specification targets only a specific container runtime.
-  If this field is indicated, the container runtime MUST use the one that matches its name if non exists it should use the one that does not indicate any `containerRuntime` value.
-  Possible values (not an exhaustive list): docker, podman, gvisor, lxc
 
 #### CDI Devices
 
@@ -203,8 +196,6 @@ The `containerEdits` field has the following definition:
     * `timeout` (int, OPTIONAL) is the number of seconds before aborting the hook. If set, timeout MUST be greater than zero. If not set container runtime will wait for the hook to return.
 
 ## Error Handling
-  * Two or more files with identical `kind` values and identical `containerRuntime` field.
-    Container runtimes should surface this error when any device with that `kind` is requested.
   * Kind requested is not present in any CDI file.
     Container runtimes should surface an error when a non existent kind is requested.
   * Device (not device node) Requested does not exist.

--- a/SPEC.md
+++ b/SPEC.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-This is CDI **spec** version **0.1.0**.
+This is CDI **spec** version **0.3.0**.
 
 #### Released versions
 
@@ -16,6 +16,7 @@ Released versions of the spec are available as Git tags.
 
 | Tag  | Spec Permalink   | Change |
 | -----| -----------------| -------|
+| v0.3.0 |   | Initial tagged release of Spec |
 
 ## Overview
 
@@ -68,7 +69,7 @@ The key words "must", "must not", "required", "shall", "shall not", "should", "s
 
 ```
 {
-    "cdiVersion": "0.1.0",
+    "cdiVersion": "0.3.0",
     "kind": "<name>",
 
     "devices": [

--- a/pkg/cdi/cache_test.go
+++ b/pkg/cdi/cache_test.go
@@ -46,7 +46,7 @@ func TestNewCache(t *testing.T) {
 			name: "one spec file",
 			etc: map[string]string{
 				"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 devices:
   - name: "dev1"
@@ -66,7 +66,7 @@ devices:
 			name: "multiple spec files with override",
 			etc: map[string]string{
 				"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 devices:
   - name: "dev1"
@@ -87,7 +87,7 @@ devices:
 			},
 			run: map[string]string{
 				"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 devices:
   - name: "dev1"
@@ -108,7 +108,7 @@ devices:
 			name: "multiple spec files, with conflicts",
 			run: map[string]string{
 				"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 devices:
   - name: "dev1"
@@ -127,7 +127,7 @@ devices:
         minor: 2
 `,
 				"vendor1-other.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 devices:
   - name: "dev1"
@@ -217,7 +217,7 @@ func TestRefreshCache(t *testing.T) {
 				{
 					run: map[string]string{
 						"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 devices:
   - name: "dev1"
@@ -254,7 +254,7 @@ devices:
 				{
 					etc: map[string]string{
 						"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 devices:
   - name: "dev1"
@@ -270,7 +270,7 @@ devices:
 				{
 					run: map[string]string{
 						"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 devices:
   - name: "dev2"
@@ -313,7 +313,7 @@ devices:
 				{
 					run: map[string]string{
 						"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 devices:
   - name: "dev1"
@@ -325,7 +325,7 @@ devices:
         minor: 1
 `,
 						"vendor1-other.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 devices:
   - name: "dev2"
@@ -373,7 +373,7 @@ devices:
 				{
 					etc: map[string]string{
 						"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 devices:
   - name: "dev1"
@@ -389,7 +389,7 @@ devices:
 				{
 					run: map[string]string{
 						"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 devices:
   - name: "dev1"
@@ -430,7 +430,7 @@ devices:
 				{
 					run: map[string]string{
 						"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 devices:
   - name: "dev1"
@@ -453,7 +453,7 @@ devices:
 				{
 					run: map[string]string{
 						"vendor1-other.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 devices:
   - name: "dev1"
@@ -583,7 +583,7 @@ func TestInjectDevice(t *testing.T) {
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
   env:
@@ -640,7 +640,7 @@ devices:
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
   env:
@@ -722,7 +722,7 @@ devices:
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
   env:
@@ -881,7 +881,7 @@ devices:
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
   env:
@@ -962,7 +962,7 @@ func TestListVendorsAndClasses(t *testing.T) {
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
   env:
@@ -992,7 +992,7 @@ devices:
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
 devices:
@@ -1014,7 +1014,7 @@ devices:
         minor: 2
 `,
 					"vendor1-other.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/other-device"
 containerEdits:
 devices:
@@ -1050,7 +1050,7 @@ devices:
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
 devices:
@@ -1072,7 +1072,7 @@ devices:
         minor: 2
 `,
 					"vendor2.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor2.com/other-device"
 containerEdits:
 devices:
@@ -1092,7 +1092,7 @@ devices:
         minor: 2
 `,
 					"vendor2-other.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor2.com/another-device"
 containerEdits:
 devices:
@@ -1112,7 +1112,7 @@ devices:
         minor: 2
 `,
 					"vendor3.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor3.com/yet-another-device"
 containerEdits:
 devices:

--- a/pkg/cdi/registry_test.go
+++ b/pkg/cdi/registry_test.go
@@ -43,7 +43,7 @@ func TestRegistryResolver(t *testing.T) {
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
   env:
@@ -100,7 +100,7 @@ devices:
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
   env:
@@ -182,7 +182,7 @@ devices:
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
   env:
@@ -341,7 +341,7 @@ devices:
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
   env:
@@ -422,7 +422,7 @@ func TestRegistrySpecDB(t *testing.T) {
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
   env:
@@ -452,7 +452,7 @@ devices:
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
 devices:
@@ -474,7 +474,7 @@ devices:
         minor: 2
 `,
 					"vendor1-other.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/other-device"
 containerEdits:
 devices:
@@ -510,7 +510,7 @@ devices:
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
 devices:
@@ -532,7 +532,7 @@ devices:
         minor: 2
 `,
 					"vendor2.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor2.com/other-device"
 containerEdits:
 devices:
@@ -546,7 +546,7 @@ devices:
       - path: "/dev/vendor2-dev2"
 `,
 					"vendor2-other.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor2.com/another-device"
 containerEdits:
 devices:
@@ -560,7 +560,7 @@ devices:
       - path: "/dev/vendor2-another-dev2"
 `,
 					"vendor3.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor3.com/yet-another-device"
 containerEdits:
 devices:
@@ -635,7 +635,7 @@ func TestRegistryDeviceDB(t *testing.T) {
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
   env:
@@ -662,7 +662,7 @@ devices:
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
 devices:
@@ -684,7 +684,7 @@ devices:
         minor: 2
 `,
 					"vendor1-other.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/other-device"
 containerEdits:
 devices:
@@ -719,7 +719,7 @@ devices:
 			cdiSpecs: specDirs{
 				etc: map[string]string{
 					"vendor1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor1.com/device"
 containerEdits:
 devices:
@@ -741,7 +741,7 @@ devices:
         minor: 2
 `,
 					"vendor2.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor2.com/other-device"
 containerEdits:
 devices:
@@ -755,7 +755,7 @@ devices:
       - path: "/dev/vendor2-dev2"
 `,
 					"vendor2-other.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor2.com/another-device"
 containerEdits:
 devices:
@@ -769,7 +769,7 @@ devices:
       - path: "/dev/vendor2-another-dev2"
 `,
 					"vendor3.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind:       "vendor3.com/yet-another-device"
 containerEdits:
 devices:

--- a/pkg/cdi/spec-dirs_test.go
+++ b/pkg/cdi/spec-dirs_test.go
@@ -53,7 +53,7 @@ func TestScanSpecDirs(t *testing.T) {
 			name: "one valid file",
 			files: map[string]string{
 				"valid.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind: vendor.com/device
 devices:
   - name: "dev1"
@@ -77,7 +77,7 @@ devices:
 			name: "one invalid file",
 			files: map[string]string{
 				"invalid.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind: vendor.com/device
 devices:
   - name: "dev1"
@@ -94,7 +94,7 @@ devices:
 			name: "two valid files, one invalid file",
 			files: map[string]string{
 				"valid1.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind: vendor.com/device1
 devices:
   - name: "dev1"
@@ -103,7 +103,7 @@ devices:
         - "FOO=BAR"
 `,
 				"valid2.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind: vendor.com/device2
 devices:
   - name: "dev1"
@@ -112,7 +112,7 @@ devices:
         - "FOO=BAR"
 `,
 				"invalid.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind: vendor.com/device
 devices:
   - name: "dev1"
@@ -139,7 +139,7 @@ devices:
 			name: "one valid file, one invalid file, abort on first error",
 			files: map[string]string{
 				"valid.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind: vendor.com/device
 devices:
   - name: "dev1"
@@ -148,7 +148,7 @@ devices:
         - "FOO=BAR"
 `,
 				"invalid.yaml": `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind: vendor.com/device
 devices:
   - name: "dev1"

--- a/pkg/cdi/spec.go
+++ b/pkg/cdi/spec.go
@@ -33,6 +33,7 @@ var (
 	validSpecVersions = map[string]struct{}{
 		"0.1.0": {},
 		"0.2.0": {},
+		"0.3.0": {},
 	}
 )
 

--- a/pkg/cdi/spec.go
+++ b/pkg/cdi/spec.go
@@ -131,8 +131,8 @@ func (s *Spec) edits() *ContainerEdits {
 
 // Validate the Spec.
 func (s *Spec) validate() (map[string]*Device, error) {
-	if _, ok := validSpecVersions[s.Version]; !ok {
-		return nil, errors.Errorf("invalid version %q", s.Version)
+	if err := validateVersion(s.Version); err != nil {
+		return nil, err
 	}
 	if err := ValidateVendorName(s.vendor); err != nil {
 		return nil, err
@@ -157,6 +157,15 @@ func (s *Spec) validate() (map[string]*Device, error) {
 	}
 
 	return devices, nil
+}
+
+// validateVersion checks whether the specified spec version is supported.
+func validateVersion(version string) error {
+	if _, ok := validSpecVersions[version]; !ok {
+		return errors.Errorf("invalid version %q", version)
+	}
+
+	return nil
 }
 
 // Parse raw CDI Spec file data.

--- a/pkg/cdi/spec_test.go
+++ b/pkg/cdi/spec_test.go
@@ -346,3 +346,7 @@ func mkTestFile(t *testing.T, data []byte) (string, error) {
 	tmp.Close()
 	return file, nil
 }
+
+func TestCurrentVersionIsValid(t *testing.T) {
+	require.NoError(t, validateVersion(cdi.CurrentVersion))
+}

--- a/pkg/cdi/spec_test.go
+++ b/pkg/cdi/spec_test.go
@@ -57,7 +57,7 @@ devices:
 		{
 			name: "valid",
 			data: `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind: vendor.com/device
 devices:
   - name: "dev1"
@@ -134,7 +134,7 @@ devices:
 		{
 			name: "invalid, missing vendor/class",
 			data: `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 devices:
   - name: "dev1"
     containerEdits:
@@ -146,7 +146,7 @@ devices:
 		{
 			name: "invalid, invalid vendor",
 			data: `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind: vendor.com-/device
 devices:
   - name: "dev1"
@@ -159,7 +159,7 @@ devices:
 		{
 			name: "invalid, invalid class",
 			data: `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind: vendor.com/device=
 devices:
   - name: "dev1"
@@ -172,7 +172,7 @@ devices:
 		{
 			name: "invalid, invalid device",
 			data: `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind: vendor.com/device
 devices:
   - name: "dev1"
@@ -182,7 +182,7 @@ devices:
 		{
 			name: "invalid, conflicting devices",
 			data: `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind: vendor.com/device
 devices:
   - name: "dev1"
@@ -203,7 +203,7 @@ devices:
 		{
 			name: "valid",
 			data: `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind: vendor.com/device
 devices:
   - name: "dev1"
@@ -280,7 +280,7 @@ devices:
 			name:     "valid",
 			priority: 1,
 			data: `
-cdiVersion: "0.2.0"
+cdiVersion: "0.3.0"
 kind: vendor.com/device
 devices:
   - name: "dev1"

--- a/pkg/devices_test.go
+++ b/pkg/devices_test.go
@@ -210,7 +210,7 @@ func TestUpdateOCISpecForDevicesWithSpecs(t *testing.T) {
 			devices: []string{"vendor.com/device=ABC", "vstartand.org/prodsnow=XYZ"},
 			specs: map[string]*cdispec.Spec{
 				"vendor.com/device": {
-					Version: "0.2.0",
+					Version: "0.3.0",
 					Kind:    "vendor.com/device",
 					Devices: []cdispec.Device{
 						{
@@ -237,7 +237,7 @@ func TestUpdateOCISpecForDevicesWithSpecs(t *testing.T) {
 					},
 				},
 				"vstartand.org/prodsnow": {
-					Version: "0.2.0",
+					Version: "0.3.0",
 					Kind:    "vstartand.org/prodsnow",
 					Devices: []cdispec.Device{
 						{
@@ -282,7 +282,7 @@ func TestUpdateOCISpecForDevicesWithSpecs(t *testing.T) {
 			devices: []string{"BAR", "ABC"},
 			specs: map[string]*cdispec.Spec{
 				"vendor.com/device": {
-					Version: "0.2.0",
+					Version: "0.3.0",
 					Kind:    "vendor.com/device",
 					Devices: []cdispec.Device{
 						{
@@ -309,7 +309,7 @@ func TestUpdateOCISpecForDevicesWithSpecs(t *testing.T) {
 					},
 				},
 				"vstartand.org/prodsnow": {
-					Version: "0.2.0",
+					Version: "0.3.0",
 					Kind:    "vstartand.org/prodsnow",
 					Devices: []cdispec.Device{
 						{
@@ -354,7 +354,7 @@ func TestUpdateOCISpecForDevicesWithSpecs(t *testing.T) {
 			devices: []string{"BAR"},
 			specs: map[string]*cdispec.Spec{
 				"vendor.com/device": {
-					Version: "0.2.0",
+					Version: "0.3.0",
 					Kind:    "vendor.com/device",
 					Devices: []cdispec.Device{
 						{

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -11,10 +11,6 @@
             "description": "The kind of the device usually of the form 'vendor.com/device'",
             "type": "string"
         },
-        "containerRuntime": {
-            "description": "A list of container runtimes this spec applies to",
-            "$ref": "defs.json#/definitions/ArrayOfStrings"
-        },
         "devices": {
             "type": "array",
             "items": {

--- a/schema/testdata/good/minimal.json
+++ b/schema/testdata/good/minimal.json
@@ -1,5 +1,5 @@
 {
-  "cdiVersion": "0.2.0",
+  "cdiVersion": "0.3.0",
   "kind": "vendor.com/device",
   "devices": [
     {

--- a/schema/testdata/good/spec-example.json
+++ b/schema/testdata/good/spec-example.json
@@ -1,5 +1,5 @@
 {
-  "cdiVersion": "0.2.0",
+  "cdiVersion": "0.3.0",
   "kind": "vendor.com/device",
   "devices": [
     {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -2,6 +2,9 @@ package specs
 
 import "os"
 
+// CurrentVersion is the current version of the Spec.
+const CurrentVersion = "0.2.0"
+
 // Spec is the base configuration for CDI
 type Spec struct {
 	Version          string   `json:"cdiVersion"`

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -3,7 +3,7 @@ package specs
 import "os"
 
 // CurrentVersion is the current version of the Spec.
-const CurrentVersion = "0.2.0"
+const CurrentVersion = "0.3.0"
 
 // Spec is the base configuration for CDI
 type Spec struct {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -7,9 +7,8 @@ const CurrentVersion = "0.2.0"
 
 // Spec is the base configuration for CDI
 type Spec struct {
-	Version          string   `json:"cdiVersion"`
-	Kind             string   `json:"kind"`
-	ContainerRuntime []string `json:"containerRuntime,omitempty"`
+	Version string `json:"cdiVersion"`
+	Kind    string `json:"kind"`
 
 	Devices        []Device       `json:"devices"`
 	ContainerEdits ContainerEdits `json:"containerEdits,omitempty"`

--- a/specs-go/oci_test.go
+++ b/specs-go/oci_test.go
@@ -307,7 +307,7 @@ func TestApplyOCIEdits(t *testing.T) {
 			name:   "edit empty spec",
 			config: &spec.Spec{},
 			cdiSpec: &Spec{
-				Version: "0.2.0",
+				Version: "0.3.0",
 				Kind:    "vendor.com/device",
 				Devices: []Device{},
 				ContainerEdits: ContainerEdits{
@@ -354,7 +354,7 @@ func TestApplyOCIEditsForDevice(t *testing.T) {
 			name:   "add device to the empty spec",
 			config: &spec.Spec{},
 			cdiSpec: &Spec{
-				Version: "0.2.0",
+				Version: "0.3.0",
 				Kind:    "vendor.com/device",
 				Devices: []Device{
 					{
@@ -395,7 +395,7 @@ func TestApplyOCIEditsForDevice(t *testing.T) {
 			name:   "device not found",
 			config: &spec.Spec{},
 			cdiSpec: &Spec{
-				Version: "0.2.0",
+				Version: "0.3.0",
 				Kind:    "vendor.com/device",
 				Devices: []Device{
 					{


### PR DESCRIPTION
This set of changes prepares for the v0.3.0 spec release. The changes include:

* Adding a `CurrentVersion` const to the spec definition
* Removing the unused `ContainerRuntimes` field from the spec
* Updating all version references to 0.3.0 (from `0.2.0` or `0.1.0`)