### PR TITLE
schema: fix Mount.Options in schema.

### DIFF
--- a/schema/defs.json
+++ b/schema/defs.json
@@ -62,7 +62,7 @@
                     "$ref": "#/definitions/FilePath"
                 },
                 "options": {
-                    "type": "string"
+                    "$ref": "#/definitions/ArrayOfStrings"
                 }
             },
             "required": [


### PR DESCRIPTION
Spec mount options should be an array of strings not a string.