### PR TITLE
[spec] Add type field for mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ $ cat > /etc/cdi/vendor.json <<EOF
     ],
     "mounts": [
       {"hostPath": "/bin/vendorBin", "containerPath": "/bin/vendorBin"},
-      {"hostPath": "/usr/lib/libVendor.so.0", "containerPath": "/usr/lib/libVendor.so.0"}
+      {"hostPath": "/usr/lib/libVendor.so.0", "containerPath": "/usr/lib/libVendor.so.0"},
+      {"hostPath": "tmpfs", "containerPath": "/tmp/data", "type": "tmpfs", "options": ["nosuid","strictatime","mode=755","size=65536k"]}
     ],
     "hooks": [
       {"createContainer": {"path": "/bin/vendor-hook"} },

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Additionally runtimes don't uniformly expose a plugin system (or even expose a p
 $ mkdir /etc/cdi
 $ cat > /etc/cdi/vendor.json <<EOF
 {
-  "cdiVersion": "0.3.0",
+  "cdiVersion": "0.4.0",
   "kind": "vendor.com/device",
   "devices": [
     {

--- a/SPEC.md
+++ b/SPEC.md
@@ -183,11 +183,7 @@ The `containerEdits` field has the following definition:
   * `mounts` (array of objects, OPTIONAL) describes the mounts that should be mounted:
     * `hostPath` (string, REQUIRED) path of the device on the host.
     * `containerPath` (string, REQUIRED) path of the device within the container.
-    * `readonly` (boolean, OPTIONAL) If set, the mount is read-only.
-    * `propagation` (string, OPTIONAL) Requested propagation mode, candidates are one of:
-      * private - No mount propagation ("private" in Linux terminology).
-      * hostToContainer - Mounts get propagated from the host to the container ("rslave" in Linux terminology).
-      * bidirectional - Mounts get propagated from the host to the container and from the container to the host ("rshared" in Linux terminology).
+    * `options` (array of strings, OPTIONAL) Mount options of the filesystem to be used.
   * `hooks` (array of objects, OPTIONAL) describes the hooks that should be ran:
     * `hookName` is the name of the hook to invoke, if the runtime is OCI compliant it should be one of {createRuntime, createContainer, startContainer, poststart, poststop}.
       Runtimes are free to allow custom hooks but it is advised for vendors to create a specific JSON file targeting that runtime

--- a/SPEC.md
+++ b/SPEC.md
@@ -111,7 +111,8 @@ The key words "must", "must not", "required", "shall", "shall not", "should", "s
                 {
                     "hostPath": "<source>",
                     "containerPath": "<destination>",
-                    "options": "<OCI Mount Options>", (optional)
+                    "type": "<OCI Mount Type>", (optional)
+                    "options": "<OCI Mount Options>" (optional)
                 }
             ],
             "hooks": [ (optional)
@@ -183,6 +184,7 @@ The `containerEdits` field has the following definition:
   * `mounts` (array of objects, OPTIONAL) describes the mounts that should be mounted:
     * `hostPath` (string, REQUIRED) path of the device on the host.
     * `containerPath` (string, REQUIRED) path of the device within the container.
+    * `type` (string, OPTIONAL) the type of the filesystem to be mounted. For bind mounts (when options include either bind or rbind), the type is a dummy, often "none" (not listed in /proc/filesystems).
     * `options` (array of strings, OPTIONAL) Mount options of the filesystem to be used.
   * `hooks` (array of objects, OPTIONAL) describes the hooks that should be ran:
     * `hookName` is the name of the hook to invoke, if the runtime is OCI compliant it should be one of {createRuntime, createContainer, startContainer, poststart, poststop}.

--- a/SPEC.md
+++ b/SPEC.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-This is CDI **spec** version **0.3.0**.
+This is CDI **spec** version **0.4.0**.
 
 #### Released versions
 
@@ -17,6 +17,7 @@ Released versions of the spec are available as Git tags.
 | Tag  | Spec Permalink   | Change |
 | -----| -----------------| -------|
 | v0.3.0 |   | Initial tagged release of Spec |
+| v0.4.0 |   | Added `type` field to Mount specification |
 
 ## Overview
 

--- a/pkg/cdi/spec.go
+++ b/pkg/cdi/spec.go
@@ -34,6 +34,7 @@ var (
 		"0.1.0": {},
 		"0.2.0": {},
 		"0.3.0": {},
+		"0.4.0": {},
 	}
 
 	// Externally set CDI Spec validation function.

--- a/pkg/cdi/spec_test.go
+++ b/pkg/cdi/spec_test.go
@@ -297,6 +297,29 @@ devices:
 			vendor: "vendor.com",
 			class:  "device",
 		},
+		{
+			name:     "valid",
+			priority: 1,
+			data: `
+cdiVersion: "0.4.0"
+kind: vendor.com/device
+devices:
+  - name: "dev1"
+    containerEdits:
+      mounts:
+        - hostPath: "tmpfs"
+          containerPath: "/usr/local/container"
+          type: "tmpfs"
+          options:
+            - "ro"
+            - "mode=755"
+            - "size=65536k"
+      env:
+        - "FOO=BAR"
+`,
+			vendor: "vendor.com",
+			class:  "device",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			file, err := mkTestFile(t, []byte(tc.data))

--- a/schema/defs.json
+++ b/schema/defs.json
@@ -63,6 +63,9 @@
                 },
                 "options": {
                     "$ref": "#/definitions/ArrayOfStrings"
+                },
+                "type": {
+                    "type": "string"
                 }
             },
             "required": [

--- a/schema/testdata/good/spec-example.json
+++ b/schema/testdata/good/spec-example.json
@@ -1,5 +1,5 @@
 {
-  "cdiVersion": "0.3.0",
+  "cdiVersion": "0.4.0",
   "kind": "vendor.com/device",
   "devices": [
     {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -3,7 +3,7 @@ package specs
 import "os"
 
 // CurrentVersion is the current version of the Spec.
-const CurrentVersion = "0.3.0"
+const CurrentVersion = "0.4.0"
 
 // Spec is the base configuration for CDI
 type Spec struct {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -45,6 +45,7 @@ type Mount struct {
 	HostPath      string   `json:"hostPath"`
 	ContainerPath string   `json:"containerPath"`
 	Options       []string `json:"options,omitempty"`
+	Type          string   `json:"type,omitempty"`
 }
 
 // Hook represents a hook that needs to be added to the OCI spec.

--- a/specs-go/oci.go
+++ b/specs-go/oci.go
@@ -95,6 +95,7 @@ func (m *Mount) ToOCI() spec.Mount {
 		Source:      m.HostPath,
 		Destination: m.ContainerPath,
 		Options:     m.Options,
+		Type:        m.Type,
 	}
 }
 


### PR DESCRIPTION
This change adds a Type field for mounts that allows for the specification of, for example, `tmpfs` mounts.

See https://github.com/opencontainers/runtime-spec/blob/main/config.md#posix-platform-mounts

Closes #45 