### PR TITLE
Relax device name restriction

### DIFF
--- a/pkg/cdi/qualified-device.go
+++ b/pkg/cdi/qualified-device.go
@@ -172,8 +172,11 @@ func ValidateDeviceName(name string) error {
 	if name == "" {
 		return errors.Errorf("invalid (empty) device name")
 	}
-	if !isLetter(rune(name[0])) {
-		return errors.Errorf("invalid name %q, should start with letter", name)
+	if !isAlphaNumeric(rune(name[0])) {
+		return errors.Errorf("invalid class %q, should start with a letter or digit", name)
+	}
+	if len(name) == 1 {
+		return nil
 	}
 	for _, c := range string(name[1 : len(name)-1]) {
 		switch {

--- a/pkg/cdi/qualified-device.go
+++ b/pkg/cdi/qualified-device.go
@@ -130,7 +130,7 @@ func ValidateVendorName(vendor string) error {
 		}
 	}
 	if !isAlphaNumeric(rune(vendor[len(vendor)-1])) {
-		return errors.Errorf("invalid vendor %q, should end with letter", vendor)
+		return errors.Errorf("invalid vendor %q, should end with a letter or digit", vendor)
 	}
 
 	return nil
@@ -158,7 +158,7 @@ func ValidateClassName(class string) error {
 		}
 	}
 	if !isAlphaNumeric(rune(class[len(class)-1])) {
-		return errors.Errorf("invalid class %q, should end with letter", class)
+		return errors.Errorf("invalid class %q, should end with a letter or digit", class)
 	}
 	return nil
 }
@@ -188,7 +188,7 @@ func ValidateDeviceName(name string) error {
 		}
 	}
 	if !isAlphaNumeric(rune(name[len(name)-1])) {
-		return errors.Errorf("invalid name %q, should start with letter", name)
+		return errors.Errorf("invalid name %q, should end with a letter or digit", name)
 	}
 	return nil
 }

--- a/pkg/cdi/qualified-device_test.go
+++ b/pkg/cdi/qualified-device_test.go
@@ -41,6 +41,13 @@ func TestQualifiedName(t *testing.T) {
 			isQualified: true,
 		},
 		{
+			device:      "vendor.com/class=0",
+			vendor:      "vendor.com",
+			class:       "class",
+			name:        "0",
+			isQualified: true,
+		},
+		{
 			device:      "vendor1.com/class1=dev1",
 			vendor:      "vendor1.com",
 			class:       "class1",


### PR DESCRIPTION
These changes allow device names to start with a digit. This means that fully-qualified device names such as:
```
vendor.com/class=0
```
is now a valid name.