### PR TITLE
Don't allow update to empty specDirs

### DIFF
--- a/pkg/cdi/spec-dirs.go
+++ b/pkg/cdi/spec-dirs.go
@@ -45,6 +45,10 @@ var (
 // WithSpecDirs returns an option to override the CDI Spec directories.
 func WithSpecDirs(dirs ...string) Option {
 	return func(c *Cache) error {
+		// If the specified directories are empty, we don't make any changes.
+		if len(dirs) == 0 {
+			return nil
+		}
 		specDirs := make([]string, len(dirs))
 		for i, dir := range dirs {
 			specDirs[i] = filepath.Clean(dir)


### PR DESCRIPTION
This change ensures that the spec dirs for a cache remain
unchanged if the list of directories passed to WithSpecDirs
is empty. This avoids inadvertently disabling CDI with an
empty config.

Signed-off-by: Evan Lezar <elezar@nvidia.com>