### PR TITLE
pkg/cdi: don't abort scan on missing Spec dir.

### DIFF
--- a/pkg/cdi/spec-dirs.go
+++ b/pkg/cdi/spec-dirs.go
@@ -17,10 +17,10 @@
 package cdi
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -79,6 +79,9 @@ func scanSpecDirs(dirs []string, scanFn scanSpecFunc) error {
 		err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 			// for initial stat failure Walk calls us with nil info
 			if info == nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					return nil
+				}
 				return err
 			}
 			// first call from Walk is for dir itself, others we skip

--- a/pkg/cdi/spec-dirs_test.go
+++ b/pkg/cdi/spec-dirs_test.go
@@ -186,7 +186,7 @@ devices:
 				classes = map[string]string{}
 			}
 
-			dirs := []string{dir}
+			dirs := []string{"/no-such-dir", dir}
 			err = scanSpecDirs(dirs, func(path string, prio int, spec *Spec, err error) error {
 				name := filepath.Base(path)
 				if err != nil {
@@ -201,12 +201,6 @@ devices:
 				}
 				return nil
 			})
-
-			if tc.files == nil {
-				require.Error(t, err)
-				require.True(t, os.IsNotExist(err))
-				return
-			}
 
 			require.Equal(t, tc.success, success)
 			require.Equal(t, tc.failure, failure)


### PR DESCRIPTION
Ignore scanning errors related to missing Spec directories. This should fix errors where a missing directory (typically /etc/cdi) prevents the resolution of devices using files from subsequent configured directories. Fixes #78 .
