### PR TITLE
pkg/cdi: fix build/vet failures on windows.

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -8,6 +8,14 @@ jobs:
   build:
     name: "Run go sanity tools"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: windows
+            goarch: amd64
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
@@ -21,13 +29,22 @@ jobs:
       run: make fmt
     - name: Vet
       run: make vet
+
+  test:
+    name: "Run tests"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
     - name: Test
       run: make test
 
 
   # Make sure binaries compile on multiple platforms.
   crossbuild:
-    name: Build/Crossbuild Binaries
+    name: "Build / Crossbuild Binaries"
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -37,7 +54,6 @@ jobs:
             goarch: amd64
           - goos: windows
             goarch: amd64
-
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,5 +1,9 @@
 on: [push, pull_request]
 name: Sanity
+
+env:
+  GO_VERSION: '1.17.x'
+
 jobs:
   build:
     name: "Run go sanity tools"
@@ -8,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.17.x
+        go-version: ${{ env.GO_VERSION }}
     - name: Install golint
       run: go get -u golang.org/x/lint/golint
     - name: Lint
@@ -19,3 +23,30 @@ jobs:
       run: make vet
     - name: Test
       run: make test
+
+
+  # Make sure binaries compile on multiple platforms.
+  crossbuild:
+    name: Build/Crossbuild Binaries
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: windows
+            goarch: amd64
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Build
+        env:
+          GOOS: ${{matrix.goos}}
+          GOARCH: ${{matrix.goarch}}
+        run: |
+          env | grep ^GO
+          make

--- a/pkg/cdi/cache_test.go
+++ b/pkg/cdi/cache_test.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"testing"
 	"time"
 
@@ -770,10 +769,10 @@ devices:
 				for {
 					select {
 					case _ = <-stopCh:
-						go syscall.Sync()
+						go osSync()
 						return
 					case _ = <-sync.C:
-						go syscall.Sync()
+						go osSync()
 						sync.Reset(2 * time.Second)
 					}
 				}

--- a/pkg/cdi/cache_test_unix.go
+++ b/pkg/cdi/cache_test_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright © 2021 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import "syscall"
+
+func osSync() {
+	syscall.Sync()
+}

--- a/pkg/cdi/cache_test_windows.go
+++ b/pkg/cdi/cache_test_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+// +build windows
+
+/*
+   Copyright © 2021 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+func osSync() {}

--- a/pkg/cdi/container-edits.go
+++ b/pkg/cdi/container-edits.go
@@ -27,8 +27,6 @@ import (
 	"github.com/container-orchestrated-devices/container-device-interface/specs-go"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	ocigen "github.com/opencontainers/runtime-tools/generate"
-
-	runc "github.com/opencontainers/runc/libcontainer/devices"
 )
 
 const (
@@ -287,37 +285,6 @@ func ensureOCIHooks(spec *oci.Spec) {
 	if spec.Hooks == nil {
 		spec.Hooks = &oci.Hooks{}
 	}
-}
-
-// fillMissingInfo fills in missing mandatory attributes from the host device.
-func (d *DeviceNode) fillMissingInfo() error {
-	if d.HostPath == "" {
-		d.HostPath = d.Path
-	}
-
-	if d.Type != "" && (d.Major != 0 || d.Type == "p") {
-		return nil
-	}
-
-	hostDev, err := runc.DeviceFromPath(d.HostPath, "rwm")
-	if err != nil {
-		return errors.Wrapf(err, "failed to stat CDI host device %q", d.HostPath)
-	}
-
-	if d.Type == "" {
-		d.Type = string(hostDev.Type)
-	} else {
-		if d.Type != string(hostDev.Type) {
-			return errors.Errorf("CDI device (%q, %q), host type mismatch (%s, %s)",
-				d.Path, d.HostPath, d.Type, string(hostDev.Type))
-		}
-	}
-	if d.Major == 0 && d.Type != "p" {
-		d.Major = hostDev.Major
-		d.Minor = hostDev.Minor
-	}
-
-	return nil
 }
 
 // sortMounts sorts the mounts in the given OCI Spec.

--- a/pkg/cdi/container-edits_unix.go
+++ b/pkg/cdi/container-edits_unix.go
@@ -1,0 +1,56 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright © 2021 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	runc "github.com/opencontainers/runc/libcontainer/devices"
+	"github.com/pkg/errors"
+)
+
+// fillMissingInfo fills in missing mandatory attributes from the host device.
+func (d *DeviceNode) fillMissingInfo() error {
+	if d.HostPath == "" {
+		d.HostPath = d.Path
+	}
+
+	if d.Type != "" && (d.Major != 0 || d.Type == "p") {
+		return nil
+	}
+
+	hostDev, err := runc.DeviceFromPath(d.HostPath, "rwm")
+	if err != nil {
+		return errors.Wrapf(err, "failed to stat CDI host device %q", d.HostPath)
+	}
+
+	if d.Type == "" {
+		d.Type = string(hostDev.Type)
+	} else {
+		if d.Type != string(hostDev.Type) {
+			return errors.Errorf("CDI device (%q, %q), host type mismatch (%s, %s)",
+				d.Path, d.HostPath, d.Type, string(hostDev.Type))
+		}
+	}
+	if d.Major == 0 && d.Type != "p" {
+		d.Major = hostDev.Major
+		d.Minor = hostDev.Minor
+	}
+
+	return nil
+}

--- a/pkg/cdi/container-edits_windows.go
+++ b/pkg/cdi/container-edits_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+// +build windows
+
+/*
+   Copyright © 2021 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import "fmt"
+
+// fillMissingInfo fills in missing mandatory attributes from the host device.
+func (d *DeviceNode) fillMissingInfo() error {
+	return fmt.Errorf("unimplemented")
+}

--- a/pkg/cdi/spec.go
+++ b/pkg/cdi/spec.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sync"
 
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -41,6 +42,7 @@ var (
 
 	// Externally set CDI Spec validation function.
 	specValidator func(*cdi.Spec) error
+	validatorLock sync.RWMutex
 )
 
 // Spec represents a single CDI Spec. It is usually loaded from a
@@ -249,11 +251,16 @@ func ParseSpec(data []byte) (*cdi.Spec, error) {
 // is used for extra CDI Spec content validation whenever a Spec file
 // loaded (using ReadSpec() or NewSpec()) or written (Spec.Write()).
 func SetSpecValidator(fn func(*cdi.Spec) error) {
+	validatorLock.Lock()
+	defer validatorLock.Unlock()
 	specValidator = fn
 }
 
 // validateSpec validates the Spec using the extneral validator.
 func validateSpec(raw *cdi.Spec) error {
+	validatorLock.RLock()
+	defer validatorLock.RUnlock()
+
 	if specValidator == nil {
 		return nil
 	}


### PR DESCRIPTION
Fix two build failures for Windows. One in stock code and another in tests, which show up as a 'go vet' failure. Fix a data read/write race which was probably triggered by the latter Windows fix slightly altering timing in some of tests... or just by sheer luck.

Update the github workflow to run sanity checking (lint, vet) both *for* Linux and Windows. The checks always run *on* a Linux distro, but they override GOOS/GOARCH for the toolchain.

Update the github worfklow to do binary test builds/cross-builds both for Linux and Windows.

