### PR TITLE
pkg/cdi: fix GetSpecErrors()/refresh read/write data race.

### DIFF
--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -409,7 +409,17 @@ func (c *Cache) GetVendorSpecs(vendor string) []*Spec {
 // GetSpecErrors returns all errors encountered for the spec during the
 // last cache refresh.
 func (c *Cache) GetSpecErrors(spec *Spec) []error {
-	return c.errors[spec.GetPath()]
+	var errors []error
+
+	c.Lock()
+	defer c.Unlock()
+
+	if errs, ok := c.errors[spec.GetPath()]; ok {
+		errors = make([]error, len(errs))
+		copy(errors, errs)
+	}
+
+	return errors
 }
 
 // GetErrors returns all errors encountered during the last


### PR DESCRIPTION
Avoid a read/write data race between refresh() and GetSpecErrors() by taking the cache lock during GetSpecErrors(). While at it, also make a copy and return that instead of the original error slice in the Spec.

Signed-off-by: Krisztian Litkey <krisztian.litkey@intel.com>