### PR TITLE
cmd, pkg, schema: stop using github.com/pkg/errors.

### DIFF
--- a/cmd/cdi/cmd/cdi-api.go
+++ b/cmd/cdi/cmd/cdi-api.go
@@ -25,7 +25,6 @@ import (
 	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	gen "github.com/opencontainers/runtime-tools/generate"
-	"github.com/pkg/errors"
 )
 
 func cdiListVendors() {
@@ -149,8 +148,8 @@ func cdiInjectDevices(format string, ociSpec *oci.Spec, patterns []string) error
 		for _, glob := range patterns {
 			match, err := filepath.Match(glob, device)
 			if err != nil {
-				return errors.Wrapf(err, "failed to match pattern %q against %q",
-					glob, device)
+				return fmt.Errorf("failed to match pattern %q against %q: %w",
+					glob, device, err)
 			}
 			if match {
 				matches[device] = struct{}{}
@@ -171,7 +170,7 @@ func cdiInjectDevices(format string, ociSpec *oci.Spec, patterns []string) error
 		}
 	}
 	if err != nil {
-		return errors.Wrapf(err, "OCI device injection failed")
+		return fmt.Errorf("OCI device injection failed: %w", err)
 	}
 
 	fmt.Printf("Updated OCI Spec:\n")
@@ -190,7 +189,7 @@ func cdiResolveDevices(ociSpecFiles ...string) error {
 	)
 
 	if cache, err = cdi.NewCache(); err != nil {
-		return errors.Wrap(err, "failed to create CDI cache instance")
+		return fmt.Errorf("failed to create CDI cache instance: %w", err)
 	}
 
 	for _, ociSpecFile := range ociSpecFiles {
@@ -209,7 +208,7 @@ func cdiResolveDevices(ociSpecFiles ...string) error {
 			}
 		}
 		if err != nil {
-			return errors.Wrapf(err, "failed to resolve devices for OCI Spec %q", ociSpecFile)
+			return fmt.Errorf("failed to resolve devices for OCI Spec %q: %w", ociSpecFile, err)
 		}
 
 		format := chooseFormat(injectCfg.output, ociSpecFile)

--- a/cmd/cdi/cmd/inject.go
+++ b/cmd/cdi/cmd/inject.go
@@ -21,8 +21,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/pkg/errors"
-
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"sigs.k8s.io/yaml"
 
@@ -74,12 +72,12 @@ func readOCISpec(path string) (*oci.Spec, error) {
 	}
 
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read OCI Spec (%q)", path)
+		return nil, fmt.Errorf("failed to read OCI Spec (%q): %w", path, err)
 	}
 
 	spec = &oci.Spec{}
 	if err = yaml.Unmarshal(data, spec); err != nil {
-		return nil, errors.Wrapf(err, "failed to parse OCI Spec (%q)", path)
+		return nil, fmt.Errorf("failed to parse OCI Spec (%q): %w", path, err)
 	}
 
 	return spec, nil

--- a/cmd/cdi/cmd/monitor.go
+++ b/cmd/cdi/cmd/monitor.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	cdi "github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
@@ -137,8 +136,8 @@ func monitorSpecDirs(args ...string) {
 func monitorDirectories(dirs ...string) (*fsnotify.Watcher, error) {
 	w, err := fsnotify.NewWatcher()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create directory watch for %s",
-			strings.Join(dirs, ","))
+		return nil, fmt.Errorf("failed to create directory watch for %s: %w",
+			strings.Join(dirs, ","), err)
 	}
 
 	for _, dir := range dirs {
@@ -148,7 +147,7 @@ func monitorDirectories(dirs ...string) (*fsnotify.Watcher, error) {
 		}
 
 		if err = w.Add(dir); err != nil {
-			return nil, errors.Wrapf(err, "failed to add %q to fsnotify watch", dir)
+			return nil, fmt.Errorf("failed to add %q to fsnotify watch: %w", dir, err)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/opencontainers/runc v1.1.2
 	github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb
 	github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.6.0
 	github.com/stretchr/testify v1.7.0
 	github.com/xeipuuv/gojsonschema v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,6 @@ github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626/go.
 github.com/opencontainers/selinux v1.9.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opencontainers/selinux v1.10.0 h1:rAiKF8hTcgLI3w0DHm6i0ylVVcOrlgR1kK99DRLDhyU=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/cdi/annotations.go
+++ b/pkg/cdi/annotations.go
@@ -17,9 +17,9 @@
 package cdi
 
 import (
+	"errors"
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -34,14 +34,14 @@ const (
 func UpdateAnnotations(annotations map[string]string, plugin string, deviceID string, devices []string) (map[string]string, error) {
 	key, err := AnnotationKey(plugin, deviceID)
 	if err != nil {
-		return annotations, errors.Wrap(err, "CDI annotation failed")
+		return annotations, fmt.Errorf("CDI annotation failed: %w", err)
 	}
 	if _, ok := annotations[key]; ok {
-		return annotations, errors.Errorf("CDI annotation failed, key %q used", key)
+		return annotations, fmt.Errorf("CDI annotation failed, key %q used", key)
 	}
 	value, err := AnnotationValue(devices)
 	if err != nil {
-		return annotations, errors.Wrap(err, "CDI annotation failed")
+		return annotations, fmt.Errorf("CDI annotation failed: %w", err)
 	}
 
 	if annotations == nil {
@@ -70,7 +70,7 @@ func ParseAnnotations(annotations map[string]string) ([]string, []string, error)
 		}
 		for _, d := range strings.Split(value, ",") {
 			if !IsQualifiedName(d) {
-				return nil, nil, errors.Errorf("invalid CDI device name %q", d)
+				return nil, nil, fmt.Errorf("invalid CDI device name %q", d)
 			}
 			devices = append(devices, d)
 		}
@@ -98,11 +98,11 @@ func AnnotationKey(pluginName, deviceID string) (string, error) {
 	name := pluginName + "_" + strings.ReplaceAll(deviceID, "/", "_")
 
 	if len(name) > maxNameLen {
-		return "", errors.Errorf("invalid plugin+deviceID %q, too long", name)
+		return "", fmt.Errorf("invalid plugin+deviceID %q, too long", name)
 	}
 
 	if c := rune(name[0]); !isAlphaNumeric(c) {
-		return "", errors.Errorf("invalid name %q, first '%c' should be alphanumeric",
+		return "", fmt.Errorf("invalid name %q, first '%c' should be alphanumeric",
 			name, c)
 	}
 	if len(name) > 2 {
@@ -111,13 +111,13 @@ func AnnotationKey(pluginName, deviceID string) (string, error) {
 			case isAlphaNumeric(c):
 			case c == '_' || c == '-' || c == '.':
 			default:
-				return "", errors.Errorf("invalid name %q, invalid charcter '%c'",
+				return "", fmt.Errorf("invalid name %q, invalid charcter '%c'",
 					name, c)
 			}
 		}
 	}
 	if c := rune(name[len(name)-1]); !isAlphaNumeric(c) {
-		return "", errors.Errorf("invalid name %q, last '%c' should be alphanumeric",
+		return "", fmt.Errorf("invalid name %q, last '%c' should be alphanumeric",
 			name, c)
 	}
 

--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -17,6 +17,8 @@
 package cdi
 
 import (
+	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -24,13 +26,10 @@ import (
 	"strings"
 	"sync"
 
-	stderr "errors"
-
 	"github.com/container-orchestrated-devices/container-device-interface/internal/multierror"
 	cdi "github.com/container-orchestrated-devices/container-device-interface/specs-go"
 	"github.com/fsnotify/fsnotify"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 // Option is an option to change some aspect of default CDI behavior.
@@ -97,7 +96,7 @@ func (c *Cache) configure(options ...Option) error {
 
 	for _, o := range options {
 		if err = o(c); err != nil {
-			return errors.Wrapf(err, "failed to apply cache options")
+			return fmt.Errorf("failed to apply cache options: %w", err)
 		}
 	}
 
@@ -159,7 +158,7 @@ func (c *Cache) refresh() error {
 			return false
 		case devPrio == oldPrio:
 			devPath, oldPath := devSpec.GetPath(), oldSpec.GetPath()
-			collectError(errors.Errorf("conflicting device %q (specs %q, %q)",
+			collectError(fmt.Errorf("conflicting device %q (specs %q, %q)",
 				name, devPath, oldPath), devPath, oldPath)
 			conflicts[name] = struct{}{}
 		}
@@ -169,7 +168,7 @@ func (c *Cache) refresh() error {
 	_ = scanSpecDirs(c.specDirs, func(path string, priority int, spec *Spec, err error) error {
 		path = filepath.Clean(path)
 		if err != nil {
-			collectError(errors.Wrapf(err, "failed to load CDI Spec"), path)
+			collectError(fmt.Errorf("failed to load CDI Spec %w", err), path)
 			return nil
 		}
 
@@ -219,7 +218,7 @@ func (c *Cache) InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, e
 	var unresolved []string
 
 	if ociSpec == nil {
-		return devices, errors.Errorf("can't inject devices, nil OCI Spec")
+		return devices, fmt.Errorf("can't inject devices, nil OCI Spec")
 	}
 
 	c.Lock()
@@ -244,12 +243,12 @@ func (c *Cache) InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, e
 	}
 
 	if unresolved != nil {
-		return unresolved, errors.Errorf("unresolvable CDI devices %s",
+		return unresolved, fmt.Errorf("unresolvable CDI devices %s",
 			strings.Join(devices, ", "))
 	}
 
 	if err := edits.Apply(ociSpec); err != nil {
-		return nil, errors.Wrap(err, "failed to inject devices")
+		return nil, fmt.Errorf("failed to inject devices: %w", err)
 	}
 
 	return nil, nil
@@ -320,7 +319,7 @@ func (c *Cache) RemoveSpec(name string) error {
 	}
 
 	err = os.Remove(path)
-	if err != nil && stderr.Is(err, fs.ErrNotExist) {
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
 		err = nil
 	}
 
@@ -485,7 +484,7 @@ func (w *watch) setup(dirs []string, dirErrors map[string]error) {
 	w.watcher, err = fsnotify.NewWatcher()
 	if err != nil {
 		for _, dir := range dirs {
-			dirErrors[dir] = errors.Wrap(err, "failed to create watcher")
+			dirErrors[dir] = fmt.Errorf("failed to create watcher: %w", err)
 		}
 		return
 	}
@@ -568,7 +567,7 @@ func (w *watch) update(dirErrors map[string]error, removed ...string) bool {
 			update = true
 		} else {
 			w.tracked[dir] = false
-			dirErrors[dir] = errors.Wrap(err, "failed to monitor for changes")
+			dirErrors[dir] = fmt.Errorf("failed to monitor for changes: %w", err)
 		}
 	}
 

--- a/pkg/cdi/cache_test.go
+++ b/pkg/cdi/cache_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi/validate"
 	cdi "github.com/container-orchestrated-devices/container-device-interface/specs-go"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 )
@@ -703,17 +702,17 @@ devices:
 					ociSpec := &oci.Spec{}
 					unresolved, err = cache.InjectDevices(ociSpec, inject)
 					if err != nil {
-						err = errors.Wrap(err, "device injection failed")
+						err = fmt.Errorf("device injection failed: %w", err)
 						return
 					}
 					if unresolved != nil {
-						err = errors.Errorf("unresolved devices %s", strings.Join(unresolved, ","))
+						err = fmt.Errorf("unresolved devices %s", strings.Join(unresolved, ","))
 						return
 					}
 
 					result := ociSpec.Linux.Devices[0].Path
 					if _, ok := expect[result]; !ok {
-						err = errors.Errorf("unexpected device path %s", result)
+						err = fmt.Errorf("unexpected device path %s", result)
 						return
 					}
 

--- a/pkg/cdi/container-edits.go
+++ b/pkg/cdi/container-edits.go
@@ -17,12 +17,12 @@
 package cdi
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/container-orchestrated-devices/container-device-interface/specs-go"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
@@ -140,7 +140,7 @@ func (e *ContainerEdits) Apply(spec *oci.Spec) error {
 			ensureOCIHooks(spec)
 			spec.Hooks.StartContainer = append(spec.Hooks.StartContainer, h.ToOCI())
 		default:
-			return errors.Errorf("unknown hook name %q", h.HookName)
+			return fmt.Errorf("unknown hook name %q", h.HookName)
 		}
 	}
 
@@ -154,7 +154,7 @@ func (e *ContainerEdits) Validate() error {
 	}
 
 	if err := ValidateEnv(e.Env); err != nil {
-		return errors.Wrap(err, "invalid container edits")
+		return fmt.Errorf("invalid container edits: %w", err)
 	}
 	for _, d := range e.DeviceNodes {
 		if err := (&DeviceNode{d}).Validate(); err != nil {
@@ -209,7 +209,7 @@ func (e *ContainerEdits) isEmpty() bool {
 func ValidateEnv(env []string) error {
 	for _, v := range env {
 		if strings.IndexByte(v, byte('=')) <= 0 {
-			return errors.Errorf("invalid environment variable %q", v)
+			return fmt.Errorf("invalid environment variable %q", v)
 		}
 	}
 	return nil
@@ -234,11 +234,11 @@ func (d *DeviceNode) Validate() error {
 		return errors.New("invalid (empty) device path")
 	}
 	if _, ok := validTypes[d.Type]; !ok {
-		return errors.Errorf("device %q: invalid type %q", d.Path, d.Type)
+		return fmt.Errorf("device %q: invalid type %q", d.Path, d.Type)
 	}
 	for _, bit := range d.Permissions {
 		if bit != 'r' && bit != 'w' && bit != 'm' {
-			return errors.Errorf("device %q: invalid persmissions %q",
+			return fmt.Errorf("device %q: invalid persmissions %q",
 				d.Path, d.Permissions)
 		}
 	}
@@ -253,13 +253,13 @@ type Hook struct {
 // Validate a hook.
 func (h *Hook) Validate() error {
 	if _, ok := validHookNames[h.HookName]; !ok {
-		return errors.Errorf("invalid hook name %q", h.HookName)
+		return fmt.Errorf("invalid hook name %q", h.HookName)
 	}
 	if h.Path == "" {
-		return errors.Errorf("invalid hook %q with empty path", h.HookName)
+		return fmt.Errorf("invalid hook %q with empty path", h.HookName)
 	}
 	if err := ValidateEnv(h.Env); err != nil {
-		return errors.Wrapf(err, "invalid hook %q", h.HookName)
+		return fmt.Errorf("invalid hook %q: %w", h.HookName, err)
 	}
 	return nil
 }

--- a/pkg/cdi/container-edits_unix.go
+++ b/pkg/cdi/container-edits_unix.go
@@ -20,8 +20,9 @@
 package cdi
 
 import (
+	"fmt"
+
 	runc "github.com/opencontainers/runc/libcontainer/devices"
-	"github.com/pkg/errors"
 )
 
 // fillMissingInfo fills in missing mandatory attributes from the host device.
@@ -36,14 +37,14 @@ func (d *DeviceNode) fillMissingInfo() error {
 
 	hostDev, err := runc.DeviceFromPath(d.HostPath, "rwm")
 	if err != nil {
-		return errors.Wrapf(err, "failed to stat CDI host device %q", d.HostPath)
+		return fmt.Errorf("failed to stat CDI host device %q: %w", d.HostPath, err)
 	}
 
 	if d.Type == "" {
 		d.Type = string(hostDev.Type)
 	} else {
 		if d.Type != string(hostDev.Type) {
-			return errors.Errorf("CDI device (%q, %q), host type mismatch (%s, %s)",
+			return fmt.Errorf("CDI device (%q, %q), host type mismatch (%s, %s)",
 				d.Path, d.HostPath, d.Type, string(hostDev.Type))
 		}
 	}

--- a/pkg/cdi/device.go
+++ b/pkg/cdi/device.go
@@ -17,9 +17,10 @@
 package cdi
 
 import (
+	"fmt"
+
 	cdi "github.com/container-orchestrated-devices/container-device-interface/specs-go"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 // Device represents a CDI device of a Spec.
@@ -69,10 +70,10 @@ func (d *Device) validate() error {
 	}
 	edits := d.edits()
 	if edits.isEmpty() {
-		return errors.Errorf("invalid device, empty device edits")
+		return fmt.Errorf("invalid device, empty device edits")
 	}
 	if err := edits.Validate(); err != nil {
-		return errors.Wrapf(err, "invalid device %q", d.Name)
+		return fmt.Errorf("invalid device %q: %w", d.Name, err)
 	}
 	return nil
 }

--- a/pkg/cdi/doc.go
+++ b/pkg/cdi/doc.go
@@ -46,7 +46,6 @@
 //      "fmt"
 //      "strings"
 //
-//      "github.com/pkg/errors"
 //      log "github.com/sirupsen/logrus"
 //
 //      "github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
@@ -58,7 +57,7 @@
 //
 //      unresolved, err := cdi.GetRegistry().InjectDevices(spec, devices)
 //      if err != nil {
-//          return errors.Wrap(err, "CDI device injection failed")
+//          return fmt.Errorf("CDI device injection failed: %w", err)
 //      }
 //
 //      log.Debug("CDI-updated OCI Spec: %s", dumpSpec(spec))
@@ -90,7 +89,6 @@
 //      "fmt"
 //      "strings"
 //
-//      "github.com/pkg/errors"
 //      log "github.com/sirupsen/logrus"
 //
 //      "github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
@@ -115,7 +113,7 @@
 //
 //      unresolved, err := registry.InjectDevices(spec, devices)
 //      if err != nil {
-//          return errors.Wrap(err, "CDI device injection failed")
+//          return fmt.Errorf("CDI device injection failed: %w", err)
 //      }
 //
 //      log.Debug("CDI-updated OCI Spec: %s", dumpSpec(spec))

--- a/pkg/cdi/qualified-device.go
+++ b/pkg/cdi/qualified-device.go
@@ -17,9 +17,8 @@
 package cdi
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // QualifiedName returns the qualified name for a device.
@@ -50,23 +49,23 @@ func ParseQualifiedName(device string) (string, string, string, error) {
 	vendor, class, name := ParseDevice(device)
 
 	if vendor == "" {
-		return "", "", device, errors.Errorf("unqualified device %q, missing vendor", device)
+		return "", "", device, fmt.Errorf("unqualified device %q, missing vendor", device)
 	}
 	if class == "" {
-		return "", "", device, errors.Errorf("unqualified device %q, missing class", device)
+		return "", "", device, fmt.Errorf("unqualified device %q, missing class", device)
 	}
 	if name == "" {
-		return "", "", device, errors.Errorf("unqualified device %q, missing device name", device)
+		return "", "", device, fmt.Errorf("unqualified device %q, missing device name", device)
 	}
 
 	if err := ValidateVendorName(vendor); err != nil {
-		return "", "", device, errors.Wrapf(err, "invalid device %q", device)
+		return "", "", device, fmt.Errorf("invalid device %q: %w", device, err)
 	}
 	if err := ValidateClassName(class); err != nil {
-		return "", "", device, errors.Wrapf(err, "invalid device %q", device)
+		return "", "", device, fmt.Errorf("invalid device %q: %w", device, err)
 	}
 	if err := ValidateDeviceName(name); err != nil {
-		return "", "", device, errors.Wrapf(err, "invalid device %q", device)
+		return "", "", device, fmt.Errorf("invalid device %q: %w", device, err)
 	}
 
 	return vendor, class, name, nil
@@ -115,22 +114,22 @@ func ParseQualifier(kind string) (string, string) {
 //   - underscore, dash, and dot ('_', '-', and '.')
 func ValidateVendorName(vendor string) error {
 	if vendor == "" {
-		return errors.Errorf("invalid (empty) vendor name")
+		return fmt.Errorf("invalid (empty) vendor name")
 	}
 	if !isLetter(rune(vendor[0])) {
-		return errors.Errorf("invalid vendor %q, should start with letter", vendor)
+		return fmt.Errorf("invalid vendor %q, should start with letter", vendor)
 	}
 	for _, c := range string(vendor[1 : len(vendor)-1]) {
 		switch {
 		case isAlphaNumeric(c):
 		case c == '_' || c == '-' || c == '.':
 		default:
-			return errors.Errorf("invalid character '%c' in vendor name %q",
+			return fmt.Errorf("invalid character '%c' in vendor name %q",
 				c, vendor)
 		}
 	}
 	if !isAlphaNumeric(rune(vendor[len(vendor)-1])) {
-		return errors.Errorf("invalid vendor %q, should end with a letter or digit", vendor)
+		return fmt.Errorf("invalid vendor %q, should end with a letter or digit", vendor)
 	}
 
 	return nil
@@ -143,22 +142,22 @@ func ValidateVendorName(vendor string) error {
 //   - underscore and dash ('_', '-')
 func ValidateClassName(class string) error {
 	if class == "" {
-		return errors.Errorf("invalid (empty) device class")
+		return fmt.Errorf("invalid (empty) device class")
 	}
 	if !isLetter(rune(class[0])) {
-		return errors.Errorf("invalid class %q, should start with letter", class)
+		return fmt.Errorf("invalid class %q, should start with letter", class)
 	}
 	for _, c := range string(class[1 : len(class)-1]) {
 		switch {
 		case isAlphaNumeric(c):
 		case c == '_' || c == '-':
 		default:
-			return errors.Errorf("invalid character '%c' in device class %q",
+			return fmt.Errorf("invalid character '%c' in device class %q",
 				c, class)
 		}
 	}
 	if !isAlphaNumeric(rune(class[len(class)-1])) {
-		return errors.Errorf("invalid class %q, should end with a letter or digit", class)
+		return fmt.Errorf("invalid class %q, should end with a letter or digit", class)
 	}
 	return nil
 }
@@ -170,10 +169,10 @@ func ValidateClassName(class string) error {
 //   - underscore, dash, dot, colon ('_', '-', '.', ':')
 func ValidateDeviceName(name string) error {
 	if name == "" {
-		return errors.Errorf("invalid (empty) device name")
+		return fmt.Errorf("invalid (empty) device name")
 	}
 	if !isAlphaNumeric(rune(name[0])) {
-		return errors.Errorf("invalid class %q, should start with a letter or digit", name)
+		return fmt.Errorf("invalid class %q, should start with a letter or digit", name)
 	}
 	if len(name) == 1 {
 		return nil
@@ -183,12 +182,12 @@ func ValidateDeviceName(name string) error {
 		case isAlphaNumeric(c):
 		case c == '_' || c == '-' || c == '.' || c == ':':
 		default:
-			return errors.Errorf("invalid character '%c' in device name %q",
+			return fmt.Errorf("invalid character '%c' in device name %q",
 				c, name)
 		}
 	}
 	if !isAlphaNumeric(rune(name[len(name)-1])) {
-		return errors.Errorf("invalid name %q, should end with a letter or digit", name)
+		return fmt.Errorf("invalid name %q, should end with a letter or digit", name)
 	}
 	return nil
 }

--- a/pkg/cdi/spec-dirs_test.go
+++ b/pkg/cdi/spec-dirs_test.go
@@ -17,12 +17,12 @@
 package cdi
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -214,7 +214,7 @@ devices:
 func mkTestDir(t *testing.T, dirs map[string]map[string]string) (string, error) {
 	tmp, err := ioutil.TempDir("", ".cache-test*")
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to create test directory")
+		return "", fmt.Errorf("failed to create test directory: %w", err)
 	}
 
 	t.Cleanup(func() {
@@ -232,16 +232,16 @@ func updateTestDir(t *testing.T, tmp string, dirs map[string]map[string]string) 
 	for sub, content := range dirs {
 		dir := filepath.Join(tmp, sub)
 		if err := os.MkdirAll(dir, 0755); err != nil {
-			return errors.Wrapf(err, "failed to create directory %q", dir)
+			return fmt.Errorf("failed to create directory %q: %w", dir, err)
 		}
 		for file, data := range content {
 			file := filepath.Join(dir, file)
 			tmp := file + ".tmp"
 			if err := ioutil.WriteFile(tmp, []byte(data), 0644); err != nil {
-				return errors.Wrapf(err, "failed to write file %q", tmp)
+				return fmt.Errorf("failed to write file %q: %w", tmp, err)
 			}
 			if err := os.Rename(tmp, file); err != nil {
-				return errors.Wrapf(err, "failed to rename %q to %q", tmp, file)
+				return fmt.Errorf("failed to rename %q to %q: %w", tmp, file, err)
 			}
 		}
 	}

--- a/pkg/cdi/spec.go
+++ b/pkg/cdi/spec.go
@@ -18,6 +18,7 @@ package cdi
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -25,7 +26,6 @@ import (
 	"sync"
 
 	oci "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 
 	cdi "github.com/container-orchestrated-devices/container-device-interface/specs-go"
@@ -78,15 +78,15 @@ func ReadSpec(path string, priority int) (*Spec, error) {
 	case os.IsNotExist(err):
 		return nil, err
 	case err != nil:
-		return nil, errors.Wrapf(err, "failed to read CDI Spec %q", path)
+		return nil, fmt.Errorf("failed to read CDI Spec %q: %w", path, err)
 	}
 
 	raw, err := ParseSpec(data)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse CDI Spec %q", path)
+		return nil, fmt.Errorf("failed to parse CDI Spec %q: %w", path, err)
 	}
 	if raw == nil {
-		return nil, errors.Errorf("failed to parse CDI Spec %q, no Spec data", path)
+		return nil, fmt.Errorf("failed to parse CDI Spec %q, no Spec data", path)
 	}
 
 	spec, err := newSpec(raw, path, priority)
@@ -120,7 +120,7 @@ func newSpec(raw *cdi.Spec, path string, priority int) (*Spec, error) {
 	spec.vendor, spec.class = ParseQualifier(spec.Kind)
 
 	if spec.devices, err = spec.validate(); err != nil {
-		return nil, errors.Wrap(err, "invalid CDI Spec")
+		return nil, fmt.Errorf("invalid CDI Spec: %w", err)
 	}
 
 	return spec, nil
@@ -147,30 +147,30 @@ func (s *Spec) write(overwrite bool) error {
 		data, err = json.Marshal(s.Spec)
 	}
 	if err != nil {
-		return errors.Wrap(err, "failed to marshal Spec file")
+		return fmt.Errorf("failed to marshal Spec file: %w", err)
 	}
 
 	dir = filepath.Dir(s.path)
 	err = os.MkdirAll(dir, 0o755)
 	if err != nil {
-		return errors.Wrap(err, "failed to create Spec dir")
+		return fmt.Errorf("failed to create Spec dir: %w", err)
 	}
 
 	tmp, err = os.CreateTemp(dir, "spec.*.tmp")
 	if err != nil {
-		return errors.Wrap(err, "failed to create Spec file")
+		return fmt.Errorf("failed to create Spec file: %w", err)
 	}
 	_, err = tmp.Write(data)
 	tmp.Close()
 	if err != nil {
-		return errors.Wrap(err, "failed to write Spec file")
+		return fmt.Errorf("failed to write Spec file: %w", err)
 	}
 
 	err = renameIn(dir, filepath.Base(tmp.Name()), filepath.Base(s.path), overwrite)
 
 	if err != nil {
 		os.Remove(tmp.Name())
-		err = errors.Wrap(err, "failed to write Spec file")
+		err = fmt.Errorf("failed to write Spec file: %w", err)
 	}
 
 	return err
@@ -230,10 +230,10 @@ func (s *Spec) validate() (map[string]*Device, error) {
 	for _, d := range s.Devices {
 		dev, err := newDevice(s, d)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed add device %q", d.Name)
+			return nil, fmt.Errorf("failed add device %q: %w", d.Name, err)
 		}
 		if _, conflict := devices[d.Name]; conflict {
-			return nil, errors.Errorf("invalid spec, multiple device %q", d.Name)
+			return nil, fmt.Errorf("invalid spec, multiple device %q", d.Name)
 		}
 		devices[d.Name] = dev
 	}
@@ -244,7 +244,7 @@ func (s *Spec) validate() (map[string]*Device, error) {
 // validateVersion checks whether the specified spec version is supported.
 func validateVersion(version string) error {
 	if _, ok := validSpecVersions[version]; !ok {
-		return errors.Errorf("invalid version %q", version)
+		return fmt.Errorf("invalid version %q", version)
 	}
 
 	return nil
@@ -255,7 +255,7 @@ func ParseSpec(data []byte) (*cdi.Spec, error) {
 	var raw *cdi.Spec
 	err := yaml.UnmarshalStrict(data, &raw)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal CDI Spec")
+		return nil, fmt.Errorf("failed to unmarshal CDI Spec: %w", err)
 	}
 	return raw, nil
 }
@@ -279,7 +279,7 @@ func validateSpec(raw *cdi.Spec) error {
 	}
 	err := specValidator(raw)
 	if err != nil {
-		return errors.Wrap(err, "Spec validation failed")
+		return fmt.Errorf("Spec validation failed: %w", err)
 	}
 	return nil
 }
@@ -329,7 +329,7 @@ func GenerateTransientSpecName(vendor, class, transientID string) string {
 func GenerateNameForSpec(raw *cdi.Spec) (string, error) {
 	vendor, class := ParseQualifier(raw.Kind)
 	if vendor == "" {
-		return "", errors.Errorf("invalid vendor/class %q in Spec", raw.Kind)
+		return "", fmt.Errorf("invalid vendor/class %q in Spec", raw.Kind)
 	}
 
 	return GenerateSpecName(vendor, class), nil
@@ -343,7 +343,7 @@ func GenerateNameForSpec(raw *cdi.Spec) (string, error) {
 func GenerateNameForTransientSpec(raw *cdi.Spec, transientID string) (string, error) {
 	vendor, class := ParseQualifier(raw.Kind)
 	if vendor == "" {
-		return "", errors.Errorf("invalid vendor/class %q in Spec", raw.Kind)
+		return "", fmt.Errorf("invalid vendor/class %q in Spec", raw.Kind)
 	}
 
 	return GenerateTransientSpecName(vendor, class, transientID), nil

--- a/pkg/cdi/spec_linux.go
+++ b/pkg/cdi/spec_linux.go
@@ -17,9 +17,9 @@
 package cdi
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -30,7 +30,7 @@ func renameIn(dir, src, dst string, overwrite bool) error {
 
 	dirf, err := os.Open(dir)
 	if err != nil {
-		return errors.Wrap(err, "rename failed")
+		return fmt.Errorf("rename failed: %w", err)
 	}
 	defer dirf.Close()
 
@@ -41,7 +41,7 @@ func renameIn(dir, src, dst string, overwrite bool) error {
 	dirFd := int(dirf.Fd())
 	err = unix.Renameat2(dirFd, src, dirFd, dst, flags)
 	if err != nil {
-		return errors.Wrap(err, "rename failed")
+		return fmt.Errorf("rename failed: %w", err)
 	}
 
 	return nil

--- a/pkg/cdi/spec_test.go
+++ b/pkg/cdi/spec_test.go
@@ -17,13 +17,13 @@
 package cdi
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 
 	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi/validate"
@@ -497,13 +497,13 @@ devices:
 func mkTestSpec(t *testing.T, data []byte) (string, error) {
 	tmp, err := ioutil.TempFile("", ".cdi-test.*."+specType(data))
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to create test file")
+		return "", fmt.Errorf("failed to create test file: %w", err)
 	}
 
 	if data != nil {
 		_, err := tmp.Write(data)
 		if err != nil {
-			return "", errors.Wrap(err, "failed to write test file content")
+			return "", fmt.Errorf("failed to write test file content: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Get rid of `github.com/pkg/errors` dependency.