### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: weekly
+  labels:
+    - "release-note-none"
+  open-pull-requests-limit: 10
+
+- package-ecosystem: gomod
+  directory: "test/tools"
+  schedule:
+    interval: weekly
+  labels:
+    - "release-note-none"
+  open-pull-requests-limit: 10
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+      interval: "daily"
+  labels:
+    - "release-note-none"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
This change adds a dependabot file for the repo. 

This is taken from the one used in podman: https://github.com/containers/podman/blob/68bf49799d6085bcc0752e15630ad18ff4d99e19/.github/dependabot.yml