### PR TITLE
Removed release-note-none label from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,16 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  ignore:
+  - versions: ["*-rc.*"]
 
 - package-ecosystem: gomod
   directory: "test/tools"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  ignore:
+  - versions: ["*-rc.*"]
 
 - package-ecosystem: "github-actions"
   directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,22 +4,16 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  labels:
-    - "release-note-none"
   open-pull-requests-limit: 10
 
 - package-ecosystem: gomod
   directory: "test/tools"
   schedule:
     interval: weekly
-  labels:
-    - "release-note-none"
   open-pull-requests-limit: 10
 
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
       interval: "daily"
-  labels:
-    - "release-note-none"
   open-pull-requests-limit: 10


### PR DESCRIPTION
The dependabot PRs created fail due to a missing label.

This PR removes the setting.

An alternative would be to add the label to the project.

See for example: https://github.com/container-orchestrated-devices/container-device-interface/pull/124#issuecomment-1469927721