### PR TITLE
Prepend yaml separator (---) to yaml output

### DIFF
--- a/pkg/cdi/spec.go
+++ b/pkg/cdi/spec.go
@@ -132,6 +132,7 @@ func (s *Spec) write(overwrite bool) error {
 
 	if filepath.Ext(s.path) == ".yaml" {
 		data, err = yaml.Marshal(s.Spec)
+		data = append([]byte("---\n"), data...)
 	} else {
 		data, err = json.Marshal(s.Spec)
 	}


### PR DESCRIPTION
This includes a YAML separator (`---`) at the start of the YAML output which makes working with multiple spec files simpler.

Closes #111 