### PR TITLE
Move parsing and name validation to cdi/parse package

### DIFF
--- a/pkg/cdi/annotations.go
+++ b/pkg/cdi/annotations.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/container-orchestrated-devices/container-device-interface/pkg/parser"
 )
 
 const (
@@ -101,14 +103,14 @@ func AnnotationKey(pluginName, deviceID string) (string, error) {
 		return "", fmt.Errorf("invalid plugin+deviceID %q, too long", name)
 	}
 
-	if c := rune(name[0]); !isAlphaNumeric(c) {
+	if c := rune(name[0]); !parser.IsAlphaNumeric(c) {
 		return "", fmt.Errorf("invalid name %q, first '%c' should be alphanumeric",
 			name, c)
 	}
 	if len(name) > 2 {
 		for _, c := range name[1 : len(name)-1] {
 			switch {
-			case isAlphaNumeric(c):
+			case parser.IsAlphaNumeric(c):
 			case c == '_' || c == '-' || c == '.':
 			default:
 				return "", fmt.Errorf("invalid name %q, invalid charcter '%c'",
@@ -116,7 +118,7 @@ func AnnotationKey(pluginName, deviceID string) (string, error) {
 			}
 		}
 	}
-	if c := rune(name[len(name)-1]); !isAlphaNumeric(c) {
+	if c := rune(name[len(name)-1]); !parser.IsAlphaNumeric(c) {
 		return "", fmt.Errorf("invalid name %q, last '%c' should be alphanumeric",
 			name, c)
 	}

--- a/pkg/cdi/device.go
+++ b/pkg/cdi/device.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/container-orchestrated-devices/container-device-interface/internal/validation"
+	"github.com/container-orchestrated-devices/container-device-interface/pkg/parser"
 	cdi "github.com/container-orchestrated-devices/container-device-interface/specs-go"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -51,7 +52,7 @@ func (d *Device) GetSpec() *Spec {
 
 // GetQualifiedName returns the qualified name for this device.
 func (d *Device) GetQualifiedName() string {
-	return QualifiedName(d.spec.GetVendor(), d.spec.GetClass(), d.Name)
+	return parser.QualifiedName(d.spec.GetVendor(), d.spec.GetClass(), d.Name)
 }
 
 // ApplyEdits applies the device-speific container edits to an OCI Spec.

--- a/pkg/cdi/qualified-device.go
+++ b/pkg/cdi/qualified-device.go
@@ -17,27 +17,36 @@
 package cdi
 
 import (
-	"fmt"
-	"strings"
+	"github.com/container-orchestrated-devices/container-device-interface/pkg/parser"
 )
 
 // QualifiedName returns the qualified name for a device.
 // The syntax for a qualified device names is
-//   "<vendor>/<class>=<name>".
+//
+//	"<vendor>/<class>=<name>".
+//
 // A valid vendor name may contain the following runes:
-//   'A'-'Z', 'a'-'z', '0'-'9', '.', '-', '_'.
+//
+//	'A'-'Z', 'a'-'z', '0'-'9', '.', '-', '_'.
+//
 // A valid class name may contain the following runes:
-//   'A'-'Z', 'a'-'z', '0'-'9', '-', '_'.
+//
+//	'A'-'Z', 'a'-'z', '0'-'9', '-', '_'.
+//
 // A valid device name may containe the following runes:
-//   'A'-'Z', 'a'-'z', '0'-'9', '-', '_', '.', ':'
+//
+//	'A'-'Z', 'a'-'z', '0'-'9', '-', '_', '.', ':'
+//
+// Deprecated: use parser.QualifiedName instead
 func QualifiedName(vendor, class, name string) string {
-	return vendor + "/" + class + "=" + name
+	return parser.QualifiedName(vendor, class, name)
 }
 
 // IsQualifiedName tests if a device name is qualified.
+//
+// Deprecated: use parser.IsQualifiedName instead
 func IsQualifiedName(device string) bool {
-	_, _, _, err := ParseQualifiedName(device)
-	return err == nil
+	return parser.IsQualifiedName(device)
 }
 
 // ParseQualifiedName splits a qualified name into device vendor, class,
@@ -45,66 +54,33 @@ func IsQualifiedName(device string) bool {
 // of the split components fail to pass syntax validation, vendor and
 // class are returned as empty, together with the verbatim input as the
 // name and an error describing the reason for failure.
+//
+// Deprecated: use parser.ParseQualifiedName instead
 func ParseQualifiedName(device string) (string, string, string, error) {
-	vendor, class, name := ParseDevice(device)
-
-	if vendor == "" {
-		return "", "", device, fmt.Errorf("unqualified device %q, missing vendor", device)
-	}
-	if class == "" {
-		return "", "", device, fmt.Errorf("unqualified device %q, missing class", device)
-	}
-	if name == "" {
-		return "", "", device, fmt.Errorf("unqualified device %q, missing device name", device)
-	}
-
-	if err := ValidateVendorName(vendor); err != nil {
-		return "", "", device, fmt.Errorf("invalid device %q: %w", device, err)
-	}
-	if err := ValidateClassName(class); err != nil {
-		return "", "", device, fmt.Errorf("invalid device %q: %w", device, err)
-	}
-	if err := ValidateDeviceName(name); err != nil {
-		return "", "", device, fmt.Errorf("invalid device %q: %w", device, err)
-	}
-
-	return vendor, class, name, nil
+	return parser.ParseQualifiedName(device)
 }
 
 // ParseDevice tries to split a device name into vendor, class, and name.
 // If this fails, for instance in the case of unqualified device names,
 // ParseDevice returns an empty vendor and class together with name set
 // to the verbatim input.
+//
+// Deprecated: use parser.ParseDevice instead
 func ParseDevice(device string) (string, string, string) {
-	if device == "" || device[0] == '/' {
-		return "", "", device
-	}
-
-	parts := strings.SplitN(device, "=", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", device
-	}
-
-	name := parts[1]
-	vendor, class := ParseQualifier(parts[0])
-	if vendor == "" {
-		return "", "", device
-	}
-
-	return vendor, class, name
+	return parser.ParseDevice(device)
 }
 
 // ParseQualifier splits a device qualifier into vendor and class.
 // The syntax for a device qualifier is
-//     "<vendor>/<class>"
+//
+//	"<vendor>/<class>"
+//
 // If parsing fails, an empty vendor and the class set to the
 // verbatim input is returned.
+//
+// Deprecated: use parser.ParseQualifier instead
 func ParseQualifier(kind string) (string, string) {
-	parts := strings.SplitN(kind, "/", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", kind
-	}
-	return parts[0], parts[1]
+	return parser.ParseQualifier(kind)
 }
 
 // ValidateVendorName checks the validity of a vendor name.
@@ -112,27 +88,10 @@ func ParseQualifier(kind string) (string, string) {
 //   - upper- and lowercase letters ('A'-'Z', 'a'-'z')
 //   - digits ('0'-'9')
 //   - underscore, dash, and dot ('_', '-', and '.')
+//
+// Deprecated: use parser.ValidateVendorName instead
 func ValidateVendorName(vendor string) error {
-	if vendor == "" {
-		return fmt.Errorf("invalid (empty) vendor name")
-	}
-	if !isLetter(rune(vendor[0])) {
-		return fmt.Errorf("invalid vendor %q, should start with letter", vendor)
-	}
-	for _, c := range string(vendor[1 : len(vendor)-1]) {
-		switch {
-		case isAlphaNumeric(c):
-		case c == '_' || c == '-' || c == '.':
-		default:
-			return fmt.Errorf("invalid character '%c' in vendor name %q",
-				c, vendor)
-		}
-	}
-	if !isAlphaNumeric(rune(vendor[len(vendor)-1])) {
-		return fmt.Errorf("invalid vendor %q, should end with a letter or digit", vendor)
-	}
-
-	return nil
+	return parser.ValidateVendorName(vendor)
 }
 
 // ValidateClassName checks the validity of class name.
@@ -140,26 +99,10 @@ func ValidateVendorName(vendor string) error {
 //   - upper- and lowercase letters ('A'-'Z', 'a'-'z')
 //   - digits ('0'-'9')
 //   - underscore and dash ('_', '-')
+//
+// Deprecated: use parser.ValidateClassName instead
 func ValidateClassName(class string) error {
-	if class == "" {
-		return fmt.Errorf("invalid (empty) device class")
-	}
-	if !isLetter(rune(class[0])) {
-		return fmt.Errorf("invalid class %q, should start with letter", class)
-	}
-	for _, c := range string(class[1 : len(class)-1]) {
-		switch {
-		case isAlphaNumeric(c):
-		case c == '_' || c == '-':
-		default:
-			return fmt.Errorf("invalid character '%c' in device class %q",
-				c, class)
-		}
-	}
-	if !isAlphaNumeric(rune(class[len(class)-1])) {
-		return fmt.Errorf("invalid class %q, should end with a letter or digit", class)
-	}
-	return nil
+	return parser.ValidateClassName(class)
 }
 
 // ValidateDeviceName checks the validity of a device name.
@@ -167,39 +110,8 @@ func ValidateClassName(class string) error {
 //   - upper- and lowercase letters ('A'-'Z', 'a'-'z')
 //   - digits ('0'-'9')
 //   - underscore, dash, dot, colon ('_', '-', '.', ':')
+//
+// Deprecated: use parser.ValidateDeviceName instead
 func ValidateDeviceName(name string) error {
-	if name == "" {
-		return fmt.Errorf("invalid (empty) device name")
-	}
-	if !isAlphaNumeric(rune(name[0])) {
-		return fmt.Errorf("invalid class %q, should start with a letter or digit", name)
-	}
-	if len(name) == 1 {
-		return nil
-	}
-	for _, c := range string(name[1 : len(name)-1]) {
-		switch {
-		case isAlphaNumeric(c):
-		case c == '_' || c == '-' || c == '.' || c == ':':
-		default:
-			return fmt.Errorf("invalid character '%c' in device name %q",
-				c, name)
-		}
-	}
-	if !isAlphaNumeric(rune(name[len(name)-1])) {
-		return fmt.Errorf("invalid name %q, should end with a letter or digit", name)
-	}
-	return nil
-}
-
-func isLetter(c rune) bool {
-	return ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z')
-}
-
-func isDigit(c rune) bool {
-	return '0' <= c && c <= '9'
-}
-
-func isAlphaNumeric(c rune) bool {
-	return isLetter(c) || isDigit(c)
+	return parser.ValidateDeviceName(name)
 }

--- a/pkg/cdi/registry.go
+++ b/pkg/cdi/registry.go
@@ -23,14 +23,12 @@ import (
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-//
 // Registry keeps a cache of all CDI Specs installed or generated on
 // the host. Registry is the primary interface clients should use to
 // interact with CDI.
 //
 // The most commonly used Registry functions are for refreshing the
 // registry and injecting CDI devices into an OCI Spec.
-//
 type Registry interface {
 	RegistryResolver
 	RegistryRefresher

--- a/pkg/cdi/spec_test.go
+++ b/pkg/cdi/spec_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi/validate"
+	"github.com/container-orchestrated-devices/container-device-interface/pkg/parser"
 	"github.com/container-orchestrated-devices/container-device-interface/schema"
 	cdi "github.com/container-orchestrated-devices/container-device-interface/specs-go"
 	"github.com/stretchr/testify/require"
@@ -487,7 +488,7 @@ devices:
 			for name, d := range spec.devices {
 				require.Equal(t, spec, d.GetSpec())
 				require.Equal(t, d, spec.GetDevice(name))
-				require.Equal(t, QualifiedName(vendor, class, name), d.GetQualifiedName())
+				require.Equal(t, parser.QualifiedName(vendor, class, name), d.GetQualifiedName())
 			}
 		})
 	}

--- a/pkg/cdi/version.go
+++ b/pkg/cdi/version.go
@@ -21,6 +21,7 @@ import (
 
 	"golang.org/x/mod/semver"
 
+	"github.com/container-orchestrated-devices/container-device-interface/pkg/parser"
 	cdi "github.com/container-orchestrated-devices/container-device-interface/specs-go"
 )
 
@@ -140,7 +141,7 @@ func requiresV050(spec *cdi.Spec) bool {
 
 	for _, d := range spec.Devices {
 		// The v0.5.0 spec allowed device names to start with a digit instead of requiring a letter
-		if len(d.Name) > 0 && !isLetter(rune(d.Name[0])) {
+		if len(d.Name) > 0 && !parser.IsLetter(rune(d.Name[0])) {
 			return true
 		}
 		edits = append(edits, &d.ContainerEdits)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1,0 +1,217 @@
+/*
+   Copyright © The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package parser
+
+import (
+	"fmt"
+	"strings"
+)
+
+// QualifiedName returns the qualified name for a device.
+// The syntax for a qualified device names is
+//
+//	"<vendor>/<class>=<name>".
+//
+// A valid vendor name may contain the following runes:
+//
+//	'A'-'Z', 'a'-'z', '0'-'9', '.', '-', '_'.
+//
+// A valid class name may contain the following runes:
+//
+//	'A'-'Z', 'a'-'z', '0'-'9', '-', '_'.
+//
+// A valid device name may containe the following runes:
+//
+//	'A'-'Z', 'a'-'z', '0'-'9', '-', '_', '.', ':'
+func QualifiedName(vendor, class, name string) string {
+	return vendor + "/" + class + "=" + name
+}
+
+// IsQualifiedName tests if a device name is qualified.
+func IsQualifiedName(device string) bool {
+	_, _, _, err := ParseQualifiedName(device)
+	return err == nil
+}
+
+// ParseQualifiedName splits a qualified name into device vendor, class,
+// and name. If the device fails to parse as a qualified name, or if any
+// of the split components fail to pass syntax validation, vendor and
+// class are returned as empty, together with the verbatim input as the
+// name and an error describing the reason for failure.
+func ParseQualifiedName(device string) (string, string, string, error) {
+	vendor, class, name := ParseDevice(device)
+
+	if vendor == "" {
+		return "", "", device, fmt.Errorf("unqualified device %q, missing vendor", device)
+	}
+	if class == "" {
+		return "", "", device, fmt.Errorf("unqualified device %q, missing class", device)
+	}
+	if name == "" {
+		return "", "", device, fmt.Errorf("unqualified device %q, missing device name", device)
+	}
+
+	if err := ValidateVendorName(vendor); err != nil {
+		return "", "", device, fmt.Errorf("invalid device %q: %w", device, err)
+	}
+	if err := ValidateClassName(class); err != nil {
+		return "", "", device, fmt.Errorf("invalid device %q: %w", device, err)
+	}
+	if err := ValidateDeviceName(name); err != nil {
+		return "", "", device, fmt.Errorf("invalid device %q: %w", device, err)
+	}
+
+	return vendor, class, name, nil
+}
+
+// ParseDevice tries to split a device name into vendor, class, and name.
+// If this fails, for instance in the case of unqualified device names,
+// ParseDevice returns an empty vendor and class together with name set
+// to the verbatim input.
+func ParseDevice(device string) (string, string, string) {
+	if device == "" || device[0] == '/' {
+		return "", "", device
+	}
+
+	parts := strings.SplitN(device, "=", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", device
+	}
+
+	name := parts[1]
+	vendor, class := ParseQualifier(parts[0])
+	if vendor == "" {
+		return "", "", device
+	}
+
+	return vendor, class, name
+}
+
+// ParseQualifier splits a device qualifier into vendor and class.
+// The syntax for a device qualifier is
+//
+//	"<vendor>/<class>"
+//
+// If parsing fails, an empty vendor and the class set to the
+// verbatim input is returned.
+func ParseQualifier(kind string) (string, string) {
+	parts := strings.SplitN(kind, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", kind
+	}
+	return parts[0], parts[1]
+}
+
+// ValidateVendorName checks the validity of a vendor name.
+// A vendor name may contain the following ASCII characters:
+//   - upper- and lowercase letters ('A'-'Z', 'a'-'z')
+//   - digits ('0'-'9')
+//   - underscore, dash, and dot ('_', '-', and '.')
+func ValidateVendorName(vendor string) error {
+	if vendor == "" {
+		return fmt.Errorf("invalid (empty) vendor name")
+	}
+	if !IsLetter(rune(vendor[0])) {
+		return fmt.Errorf("invalid vendor %q, should start with letter", vendor)
+	}
+	for _, c := range string(vendor[1 : len(vendor)-1]) {
+		switch {
+		case IsAlphaNumeric(c):
+		case c == '_' || c == '-' || c == '.':
+		default:
+			return fmt.Errorf("invalid character '%c' in vendor name %q",
+				c, vendor)
+		}
+	}
+	if !IsAlphaNumeric(rune(vendor[len(vendor)-1])) {
+		return fmt.Errorf("invalid vendor %q, should end with a letter or digit", vendor)
+	}
+
+	return nil
+}
+
+// ValidateClassName checks the validity of class name.
+// A class name may contain the following ASCII characters:
+//   - upper- and lowercase letters ('A'-'Z', 'a'-'z')
+//   - digits ('0'-'9')
+//   - underscore and dash ('_', '-')
+func ValidateClassName(class string) error {
+	if class == "" {
+		return fmt.Errorf("invalid (empty) device class")
+	}
+	if !IsLetter(rune(class[0])) {
+		return fmt.Errorf("invalid class %q, should start with letter", class)
+	}
+	for _, c := range string(class[1 : len(class)-1]) {
+		switch {
+		case IsAlphaNumeric(c):
+		case c == '_' || c == '-':
+		default:
+			return fmt.Errorf("invalid character '%c' in device class %q",
+				c, class)
+		}
+	}
+	if !IsAlphaNumeric(rune(class[len(class)-1])) {
+		return fmt.Errorf("invalid class %q, should end with a letter or digit", class)
+	}
+	return nil
+}
+
+// ValidateDeviceName checks the validity of a device name.
+// A device name may contain the following ASCII characters:
+//   - upper- and lowercase letters ('A'-'Z', 'a'-'z')
+//   - digits ('0'-'9')
+//   - underscore, dash, dot, colon ('_', '-', '.', ':')
+func ValidateDeviceName(name string) error {
+	if name == "" {
+		return fmt.Errorf("invalid (empty) device name")
+	}
+	if !IsAlphaNumeric(rune(name[0])) {
+		return fmt.Errorf("invalid class %q, should start with a letter or digit", name)
+	}
+	if len(name) == 1 {
+		return nil
+	}
+	for _, c := range string(name[1 : len(name)-1]) {
+		switch {
+		case IsAlphaNumeric(c):
+		case c == '_' || c == '-' || c == '.' || c == ':':
+		default:
+			return fmt.Errorf("invalid character '%c' in device name %q",
+				c, name)
+		}
+	}
+	if !IsAlphaNumeric(rune(name[len(name)-1])) {
+		return fmt.Errorf("invalid name %q, should end with a letter or digit", name)
+	}
+	return nil
+}
+
+// IsLetter reports whether the rune is a letter.
+func IsLetter(c rune) bool {
+	return ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z')
+}
+
+// IsDigit reports whether the rune is a digit.
+func IsDigit(c rune) bool {
+	return '0' <= c && c <= '9'
+}
+
+// IsAlphaNumeric reports whether the rune is a letter or digit.
+func IsAlphaNumeric(c rune) bool {
+	return IsLetter(c) || IsDigit(c)
+}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1,0 +1,146 @@
+/*
+   Copyright © The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQualifiedName(t *testing.T) {
+	type testCase = struct {
+		device      string
+		vendor      string
+		class       string
+		name        string
+		isQualified bool
+		isParsable  bool
+	}
+
+	for _, tc := range []*testCase{
+		{
+			device:      "vendor.com/class=dev",
+			vendor:      "vendor.com",
+			class:       "class",
+			name:        "dev",
+			isQualified: true,
+		},
+		{
+			device:      "vendor.com/class=0",
+			vendor:      "vendor.com",
+			class:       "class",
+			name:        "0",
+			isQualified: true,
+		},
+		{
+			device:      "vendor1.com/class1=dev1",
+			vendor:      "vendor1.com",
+			class:       "class1",
+			name:        "dev1",
+			isQualified: true,
+		},
+		{
+			device:      "other-vendor1.com/class_1=dev_1",
+			vendor:      "other-vendor1.com",
+			class:       "class_1",
+			name:        "dev_1",
+			isQualified: true,
+		},
+		{
+			device:      "yet_another-vendor2.com/c-lass_2=dev_1:2.3",
+			vendor:      "yet_another-vendor2.com",
+			class:       "c-lass_2",
+			name:        "dev_1:2.3",
+			isQualified: true,
+		},
+		{
+			device:     "_invalid.com/class=dev",
+			vendor:     "_invalid.com",
+			class:      "class",
+			name:       "dev",
+			isParsable: true,
+		},
+		{
+			device:     "invalid2.com-/class=dev",
+			vendor:     "invalid2.com-",
+			class:      "class",
+			name:       "dev",
+			isParsable: true,
+		},
+		{
+			device:     "invalid3.com/_class=dev",
+			vendor:     "invalid3.com",
+			class:      "_class",
+			name:       "dev",
+			isParsable: true,
+		},
+		{
+			device:     "invalid4.com/class_=dev",
+			vendor:     "invalid4.com",
+			class:      "class_",
+			name:       "dev",
+			isParsable: true,
+		},
+		{
+			device:     "invalid5.com/class=-dev",
+			vendor:     "invalid5.com",
+			class:      "class",
+			name:       "-dev",
+			isParsable: true,
+		},
+		{
+			device:     "invalid6.com/class=dev:",
+			vendor:     "invalid6.com",
+			class:      "class",
+			name:       "dev:",
+			isParsable: true,
+		},
+		{
+			device:     "*.com/*dev=*gpu*",
+			vendor:     "*.com",
+			class:      "*dev",
+			name:       "*gpu*",
+			isParsable: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			vendor, class, name, err := ParseQualifiedName(tc.device)
+			if tc.isQualified {
+				require.True(t, IsQualifiedName(tc.device), "qualified name %q", tc.device)
+				require.NoError(t, err)
+				require.Equal(t, tc.vendor, vendor, "qualified name %q", tc.device)
+				require.Equal(t, tc.class, class, "qualified name %q", tc.device)
+				require.Equal(t, tc.name, name, "qualified name %q", tc.device)
+
+				vendor, class, name = ParseDevice(tc.device)
+				require.Equal(t, tc.vendor, vendor, "parsed name %q", tc.device)
+				require.Equal(t, tc.class, class, "parse name %q", tc.device)
+				require.Equal(t, tc.name, name, "parsed name %q", tc.device)
+
+				device := QualifiedName(vendor, class, name)
+				require.Equal(t, tc.device, device, "constructed device %q", tc.device)
+			} else if tc.isParsable {
+				require.False(t, IsQualifiedName(tc.device), "parsed name %q", tc.device)
+				vendor, class, name = ParseDevice(tc.device)
+				require.Equal(t, tc.vendor, vendor, "parsed name %q", tc.device)
+				require.Equal(t, tc.class, class, "parse name %q", tc.device)
+				require.Equal(t, tc.name, name, "parsed name %q", tc.device)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This should allow golang dependencies to be better managed.

See https://github.com/docker/cli/pull/4084#pullrequestreview-1351095415