### PR TITLE
Ensure that spec files are created world readable

### DIFF
--- a/pkg/cdi/spec.go
+++ b/pkg/cdi/spec.go
@@ -156,6 +156,11 @@ func (s *Spec) write(overwrite bool) error {
 		return fmt.Errorf("failed to write Spec file: %w", err)
 	}
 
+	if err := os.Chmod(tmp.Name(), 0o644); err != nil {
+		os.Remove(tmp.Name())
+		return fmt.Errorf("failed to set read permissions on spec file: %w", err)
+	}
+
 	err = renameIn(dir, filepath.Base(tmp.Name()), filepath.Base(s.path), overwrite)
 
 	if err != nil {


### PR DESCRIPTION
In order to allow non-root applications to read the generated specs, the files must be created with 644 permissions instead of the 600 permissions that are the default for os.CreateTemp.

This change calls os.Chmod on the generated temporary file before renaming it to the final filename.