### PR TITLE
codespell: workflow, config, typos fixed

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = .git,*.pdf,*.svg
+#
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
-skip = .git,*.pdf,*.svg
+skip = .git,*.pdf,*.svg,*.sum,*.mod
 #
 # ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,19 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v1

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ EOF
 ```
 
 Assuming this specification has been generated and is available in either
-`/etc/cdi` or `/var/run/cdi` (or whereever a CDI-enabled consumer is configured
+`/etc/cdi` or `/var/run/cdi` (or wherever a CDI-enabled consumer is configured
 to read CDI specifications from), the devices can be accessed through their
 fully-qualified device names.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -15,7 +15,7 @@ This is CDI **spec** version **0.6.0**.
 Any modifications to the **spec** will result in at least a minor version bump. When releasing changes
 that only affect the API also implemented in this repository, the patch version will be bumped.
 
-*Note*: The **spec** is still under active development and there exists the posibility of breaking changes being
+*Note*: The **spec** is still under active development and there exists the possibility of breaking changes being
 introduced with new versions.
 ### Released versions
 
@@ -72,7 +72,7 @@ For the purposes of this proposal, we define the following terms:
 - _container runtime_ which refers to the higher level component users tend to interact with for managing containers. It may also include lower level components that implement management of containers and pods (sets of containers). e.g: docker, podman, ...
 - _container runtime interface integration_ which refers to a server that implements the Container Runtime Interface (CRI) services, e.g: containerd+cri, cri-o, ...
 
-The key words "must", "must not", "required", "shall", "shall not", "should", "should not", "recommended", "may" and "optonal" are used as specified in [RFC 2119][rfc-2119].
+The key words "must", "must not", "required", "shall", "shall not", "should", "should not", "recommended", "may" and "optional" are used as specified in [RFC 2119][rfc-2119].
 
 [rfc-2119]: https://www.ietf.org/rfc/rfc2119.txt
 

--- a/cmd/cdi/cmd/resolve.go
+++ b/cmd/cdi/cmd/resolve.go
@@ -57,7 +57,7 @@ func resolveDevices(ociSpecFiles ...string) error {
 
 		resolved, err := cdi.ResolveDevices(ociSpec)
 		if err != nil {
-			return errors.Wrapf(err, "CDI device resolution faile in %q",
+			return errors.Wrapf(err, "CDI device resolution failed in %q",
 				ociSpecFile)
 		}
 

--- a/pkg/cdi/annotations.go
+++ b/pkg/cdi/annotations.go
@@ -113,7 +113,7 @@ func AnnotationKey(pluginName, deviceID string) (string, error) {
 			case parser.IsAlphaNumeric(c):
 			case c == '_' || c == '-' || c == '.':
 			default:
-				return "", fmt.Errorf("invalid name %q, invalid charcter '%c'",
+				return "", fmt.Errorf("invalid name %q, invalid character '%c'",
 					name, c)
 			}
 		}

--- a/pkg/cdi/container-edits.go
+++ b/pkg/cdi/container-edits.go
@@ -238,7 +238,7 @@ func (d *DeviceNode) Validate() error {
 	}
 	for _, bit := range d.Permissions {
 		if bit != 'r' && bit != 'w' && bit != 'm' {
-			return fmt.Errorf("device %q: invalid persmissions %q",
+			return fmt.Errorf("device %q: invalid permissions %q",
 				d.Path, d.Permissions)
 		}
 	}

--- a/pkg/cdi/doc.go
+++ b/pkg/cdi/doc.go
@@ -137,7 +137,7 @@
 // were loaded from. The later a directory occurs in the list of CDI
 // directories to scan, the higher priority Spec files loaded from that
 // directory are assigned to. When two or more Spec files define the
-// same device, conflict is resolved by chosing the definition from the
+// same device, conflict is resolved by choosing the definition from the
 // Spec file with the highest priority.
 //
 // The default CDI directory configuration is chosen to encourage
@@ -197,7 +197,7 @@
 //     return registry.SpecDB().WriteSpec(spec, specName)
 // }
 //
-// Similary, generating and later cleaning up transient Spec files can be
+// Similarly, generating and later cleaning up transient Spec files can be
 // done with code fragments similar to the following. These transient Spec
 // files are temporary Spec files with container-specific parametrization.
 // They are typically created before the associated container is created

--- a/pkg/cdi/qualified-device.go
+++ b/pkg/cdi/qualified-device.go
@@ -29,7 +29,7 @@ import (
 //
 //	'A'-'Z', 'a'-'z', '0'-'9', '.', '-', '_'.
 //
-// A valid device name may containe the following runes:
+// A valid device name may contain the following runes:
 //
 //	'A'-'Z', 'a'-'z', '0'-'9', '-', '_', '.', ':'
 //

--- a/pkg/cdi/spec.go
+++ b/pkg/cdi/spec.go
@@ -209,7 +209,7 @@ func (s *Spec) validate() (map[string]*Device, error) {
 
 	minVersion, err := MinimumRequiredVersion(s.Spec)
 	if err != nil {
-		return nil, fmt.Errorf("could not determine minumum required version: %v", err)
+		return nil, fmt.Errorf("could not determine minimum required version: %v", err)
 	}
 	if newVersion(minVersion).IsGreaterThan(newVersion(s.Version)) {
 		return nil, fmt.Errorf("the spec version must be at least v%v", minVersion)
@@ -311,7 +311,7 @@ func GenerateSpecName(vendor, class string) string {
 // match the vendor and class of the CDI Spec. transientID should be
 // unique among all CDI users on the same host that might generate
 // transient Spec files using the same vendor/class combination. If
-// the external entity to which the lifecycle of the tranient Spec
+// the external entity to which the lifecycle of the transient Spec
 // is tied to has a unique ID of its own, then this is usually a
 // good choice for transientID.
 //

--- a/pkg/cdi/version.go
+++ b/pkg/cdi/version.go
@@ -56,7 +56,7 @@ var validSpecVersions = requiredVersionMap{
 	v060: requiresV060,
 }
 
-// MinimumRequiredVersion determines the minumum spec version for the input spec.
+// MinimumRequiredVersion determines the minimum spec version for the input spec.
 func MinimumRequiredVersion(spec *cdi.Spec) (string, error) {
 	minVersion := validSpecVersions.requiredVersion(spec)
 	return minVersion.String(), nil

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -30,7 +30,7 @@ import (
 //
 //	'A'-'Z', 'a'-'z', '0'-'9', '.', '-', '_'.
 //
-// A valid device name may containe the following runes:
+// A valid device name may contain the following runes:
 //
 //	'A'-'Z', 'a'-'z', '0'-'9', '-', '_', '.', ':'
 func QualifiedName(vendor, class, name string) string {

--- a/specs-go/oci.go
+++ b/specs-go/oci.go
@@ -22,7 +22,7 @@ func ApplyOCIEditsForDevice(config *spec.Spec, cdi *Spec, dev string) error {
 	return fmt.Errorf("CDI: device %q not found for spec %q", dev, cdi.Kind)
 }
 
-// ApplyOCIEdits applies the OCI edits the CDI spec declares globablly
+// ApplyOCIEdits applies the OCI edits the CDI spec declares globally
 func ApplyOCIEdits(config *spec.Spec, cdi *Spec) error {
 	return ApplyEditsToOCISpec(config, &cdi.ContainerEdits)
 }


### PR DESCRIPTION
While listening to @elezar  giving a presentation, decided to check the CDI out: Having typos free code would be very useful for 1.0 release ;)