### PR TITLE
Add cncf tags required files

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,2 @@
+# Security Policy
+

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Please refer to the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).


### PR DESCRIPTION
This change adds files as required for [moving the repo to cncf-tags](https://github.com/cncf/toc/blob/main/tags/cncf-tags-github-org.md#mandatory-files).

This adds:
* A `code-of-conduct.md` referencing the CNCF Code of Conduct
* An empty Security Policy