### PR TITLE
log the unresolved CDI devices only

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Install golint
-      run: go get -u golang.org/x/lint/golint
+      run: go install golang.org/x/lint/golint@latest
     - name: Lint
       run: make lint
     - name: Fmt

--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -49,7 +49,7 @@ type Cache struct {
 }
 
 // WithAutoRefresh returns an option to control automatic Cache refresh.
-// By default auto-refresh is enabled, the list of Spec directories are
+// By default, auto-refresh is enabled, the list of Spec directories are
 // monitored and the Cache is automatically refreshed whenever a change
 // is detected. This option can be used to disable this behavior when a
 // manually refreshed mode is preferable.
@@ -203,7 +203,7 @@ func (c *Cache) refresh() error {
 // RefreshIfRequired triggers a refresh if necessary.
 func (c *Cache) refreshIfRequired(force bool) (bool, error) {
 	// We need to refresh if
-	// - it's forced by an explicitly call to Refresh() in manual mode
+	// - it's forced by an explicit call to Refresh() in manual mode
 	// - a missing Spec dir appears (added to watch) in auto-refresh mode
 	if force || (c.autoRefresh && c.watch.update(c.dirErrors)) {
 		return true, c.refresh()
@@ -244,7 +244,7 @@ func (c *Cache) InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, e
 
 	if unresolved != nil {
 		return unresolved, fmt.Errorf("unresolvable CDI devices %s",
-			strings.Join(devices, ", "))
+			strings.Join(unresolved, ", "))
 	}
 
 	if err := edits.Apply(ociSpec); err != nil {

--- a/pkg/cdi/cache_test.go
+++ b/pkg/cdi/cache_test.go
@@ -17,6 +17,7 @@
 package cdi
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -818,12 +819,13 @@ func TestInjectDevice(t *testing.T) {
 		run map[string]string
 	}
 	type testCase struct {
-		name       string
-		cdiSpecs   specDirs
-		ociSpec    *oci.Spec
-		devices    []string
-		result     *oci.Spec
-		unresolved []string
+		name        string
+		cdiSpecs    specDirs
+		ociSpec     *oci.Spec
+		devices     []string
+		result      *oci.Spec
+		unresolved  []string
+		expectedErr error
 	}
 	for _, tc := range []*testCase{
 		{
@@ -1155,6 +1157,7 @@ devices:
 			unresolved: []string{
 				"vendor1.com/device=dev2",
 			},
+			expectedErr: errors.New("unresolvable CDI devices vendor1.com/device=dev2"),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1180,6 +1183,7 @@ devices:
 			unresolved, err := cache.InjectDevices(tc.ociSpec, tc.devices...)
 			if len(tc.unresolved) != 0 {
 				require.NotNil(t, err)
+				require.Equal(t, tc.expectedErr, err)
 				require.Equal(t, tc.unresolved, unresolved)
 				return
 			}


### PR DESCRIPTION
In `InjectDevices()` we are currently error-logging the whole list of devices instead of the device handles which weren't resolved